### PR TITLE
update: services page improvements

### DIFF
--- a/src/components/ServiceRedirectButton/index.tsx
+++ b/src/components/ServiceRedirectButton/index.tsx
@@ -8,11 +8,13 @@ import { useAuth } from "@/contexts/AuthContext";
 
 
 function ServiceRedirectButton({
+  className,
   service,
   endpoint,
   additionalExposedPathArgs,
   healthcheckPath = "",
 }: {
+  className?: string;
   service: Service;
   endpoint: string;
   additionalExposedPathArgs?: string;
@@ -76,13 +78,14 @@ function ServiceRedirectButton({
 
   return isAlive ? (
     <Link
+      className={`${className ?? ""}`}
       to={redirectLink}
       target="_blank"
     >
       <ExternalLink />
     </Link>
   ) : (
-    <Loader2 className="animate-spin" color={OscarColors.DarkGrayText} />
+    <Loader2 className={`animate-spin ${className ?? ""}`} color={OscarColors.DarkGrayText} />
   );
 }
 

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -146,7 +146,7 @@ function GenericTable<T extends object>({
             <TableRow
               key={rowIndex}
               onClick={() => onRowClick?.(item)}
-              className="cursor-pointer"
+              className={`${onRowClick ? 'cursor-pointer' : ''}`}
             >
               <TableCell>
                 <Checkbox

--- a/src/pages/ui/services/components/ServicesList/index.tsx
+++ b/src/pages/ui/services/components/ServicesList/index.tsx
@@ -16,6 +16,8 @@ import { useAuth } from "@/contexts/AuthContext";
 import MoreActionsPopover from "./components/MoreActionsPopover";
 import ResponsiveOwnerField from "@/components/ResponsiveOwnerField";
 import { errorMessage } from "@/lib/error";
+import ServiceRedirectButton from "@/components/ServiceRedirectButton";
+import { shortenFullname } from "@/lib/utils";
 
 function ServicesList() {
   const { services, servicesAreLoading, setServices, setFormService, filter } =
@@ -108,13 +110,9 @@ function ServicesList() {
           <GenericTable<Service>
             data={filteredServices}
             idKey="name"
-            onRowClick={(item) => {
-              setFormService(item);
-              navigate(`/ui/services/${item.name}/settings`);
-            }}
             columns={[
-              { header: "Name", accessor: "name", sortBy: "name" },
-              { header: "Owner", accessor: (row) => (<ResponsiveOwnerField owner={row.owner} copy={false} />), sortBy: "owner" },
+              { header: "Name", accessor: (row) => (<Link to={`/ui/services/${row.name}/settings`}>{row.name}</Link>), sortBy: "name" },
+              { header: "Owner", accessor: (row) => (<ResponsiveOwnerField owner={row.labels["owner_name"] ? shortenFullname(row.labels["owner_name"]) : row.owner} sub={row.owner} />), sortBy: "owner" },
               { header: "Image", accessor: "image", sortBy: "image" },
               { header: "CPU", accessor: "cpu", sortBy: "cpu" },
               { header: "Memory", accessor: "memory", sortBy: "memory" },
@@ -142,14 +140,25 @@ function ServicesList() {
               },
               {
                 button: (item) => (
-                  <InvokePopover
-                    service={item}
-                    triggerRenderer={
-                      <Button variant={"link"} ref={(elem) => {buttonRef.current?.set(item.name, elem!)}} size="icon" tooltipLabel="Invoke">
-                        <Terminal />
-                      </Button>
-                    }
-                  />
+                  <>
+                  {item.expose.max_scale != "0" ?
+                    <ServiceRedirectButton 
+                      className="flex items-center justify-center ml-2 mr-2 "
+                      service={item}
+                      endpoint={authData.endpoint}
+                      healthcheckPath={item.expose.health_path}
+                    />
+                    :
+                    <InvokePopover
+                      service={item}
+                      triggerRenderer={
+                        <Button variant={"link"} ref={(elem) => {buttonRef.current?.set(item.name, elem!)}} size="icon" tooltipLabel="Invoke">
+                          <Terminal />
+                        </Button>
+                      }
+                    />
+                  }
+                  </>
                 ),
               },
               {

--- a/src/pages/ui/services/models/service.ts
+++ b/src/pages/ui/services/models/service.ts
@@ -179,6 +179,7 @@ export interface Service {
     nodePort: string,
     default_command: boolean,
     set_auth: boolean
+    health_path: string;
   };
 }
 


### PR DESCRIPTION
This pull request enhances the service management UI by improving the flexibility and usability of service-related components and tables. The main changes focus on making the `ServiceRedirectButton` more reusable, improving the presentation of service information in tables, and refining how users interact with service rows.

**Component and UI improvements:**

* The `ServiceRedirectButton` component now accepts an optional `className` prop, allowing for more flexible styling when used in different contexts. The component also applies this class to both its active and loading states. [[1]](diffhunk://#diff-74bb63e3e0a05c493d2b18739edda5a57ee0d73b43a462ef04d9834cf7f60d4bR11-R17) [[2]](diffhunk://#diff-74bb63e3e0a05c493d2b18739edda5a57ee0d73b43a462ef04d9834cf7f60d4bR81-R88)
* The `ServiceRedirectButton` is now integrated into the `ServicesList` table, providing a direct redirect option for services with external endpoints. The button is conditionally rendered based on the service's scaling configuration. [[1]](diffhunk://#diff-8b741250d55af4448d6f18a817a050aaaeaec6a5be62f9540e6175eb03738ba1R143-R151) [[2]](diffhunk://#diff-8b741250d55af4448d6f18a817a050aaaeaec6a5be62f9540e6175eb03738ba1R160-R161) [[3]](diffhunk://#diff-8b741250d55af4448d6f18a817a050aaaeaec6a5be62f9540e6175eb03738ba1R19-R20)

**Table and data presentation changes:**

* The "Name" column in the services table now displays the service name as a clickable link that navigates directly to the service's settings, instead of using a row click handler.
* The "Owner" column now uses the shortened owner name from the service's labels when available, improving readability.
* The `GenericTable` row styling is now conditional: the pointer cursor is only shown if a row click handler is present, making the UI more intuitive.

**Data model update:**

* The `Service` model now includes a `health_path` property, supporting the new health check integration in the redirect button.