### PR TITLE
feat(dashboard): add managed volumes support in hub and volumes views

### DIFF
--- a/src/api/volumes/createVolumesApi.ts
+++ b/src/api/volumes/createVolumesApi.ts
@@ -1,0 +1,9 @@
+import { ManagedVolumeCreateRequest } from "@/pages/ui/services/models/service";
+import axios from "axios";
+
+async function createVolumesApi(volume: ManagedVolumeCreateRequest) {
+  const response = await axios.post("/system/volumes", volume);
+  return response.data;
+}
+
+export default createVolumesApi;

--- a/src/api/volumes/deleteVolumesApi.ts
+++ b/src/api/volumes/deleteVolumesApi.ts
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+async function deleteVolumesApi(volumeName: string) {
+  const response = await axios.delete(`/system/volumes/${volumeName}`);
+  return response.data;
+}
+
+export default deleteVolumesApi;

--- a/src/api/volumes/getVolumesApi.ts
+++ b/src/api/volumes/getVolumesApi.ts
@@ -1,0 +1,9 @@
+import { ManagedVolume } from "@/pages/ui/services/models/service";
+import axios from "axios";
+
+async function getVolumesApi() {
+  const response = await axios.get("/system/volumes");
+  return response.data as ManagedVolume[];
+}
+
+export default getVolumesApi;

--- a/src/api/volumes/getVolumesApi.ts
+++ b/src/api/volumes/getVolumesApi.ts
@@ -1,9 +1,10 @@
-import { ManagedVolume } from "@/pages/ui/services/models/service";
+import { Volumes } from "@/pages/ui/services/models/service";
 import axios from "axios";
 
 async function getVolumesApi() {
   const response = await axios.get("/system/volumes");
-  return response.data as ManagedVolume[];
+  console.log("getVolumesApi response:", response.data);
+  return response.data as Volumes;
 }
 
 export default getVolumesApi;

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,5 +1,17 @@
 import OscarLogo from "@/assets/oscar-big.png";
-import { Boxes, Codesandbox, Database, Info, LogOut, Notebook, Route, BarChart2, ChartPie, Terminal } from "lucide-react";
+import {
+  BarChart2,
+  Boxes,
+  ChartPie,
+  Codesandbox,
+  Database,
+  HardDrive,
+  Info,
+  LogOut,
+  Notebook,
+  Route,
+  Terminal,
+} from "lucide-react";
 import OscarColors from "@/styles";
 import { useAuth } from "@/contexts/AuthContext";
 import {
@@ -36,6 +48,11 @@ function AppSidebar() {
       title: "Buckets",
       icon: <Database size={20} />,
       path: "/minio",
+    },
+    {
+      title: "Volumes",
+      icon: <HardDrive size={20} />,
+      path: "/volumes",
     },
     {
       title: "Notebooks",

--- a/src/contexts/Volumes/VolumesContext.tsx
+++ b/src/contexts/Volumes/VolumesContext.tsx
@@ -1,0 +1,105 @@
+import createVolumesApi from "@/api/volumes/createVolumesApi";
+import deleteVolumesApi from "@/api/volumes/deleteVolumesApi";
+import getVolumesApi from "@/api/volumes/getVolumesApi";
+import { alert } from "@/lib/alert";
+import React, { createContext, useContext, useState } from "react";
+import {
+  ManagedVolume,
+  ManagedVolumeCreateRequest,
+} from "@/pages/ui/services/models/service";
+
+interface VolumesFilterProps {
+  myVolumes: boolean;
+  query: string;
+  by: VolumeFilterBy;
+}
+
+export enum VolumeFilterBy {
+  NAME = "name",
+  OWNER = "owner",
+  SERVICE = "service",
+}
+
+export type VolumesProviderData = {
+  volumesFilter: VolumesFilterProps;
+  setVolumesFilter: (filter: VolumesFilterProps) => void;
+  volumes: ManagedVolume[];
+  volumesAreLoading: boolean;
+  setVolumes: (volumes: ManagedVolume[]) => void;
+  updateVolumes: () => Promise<void>;
+  createVolume: (volume: ManagedVolumeCreateRequest) => Promise<void>;
+  deleteVolume: (volumeName: string) => Promise<void>;
+};
+
+export const VolumesContext = createContext({} as VolumesProviderData);
+
+export const VolumesProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [volumes, setVolumes] = useState<ManagedVolume[]>([]);
+  const [volumesAreLoading, setVolumesAreLoading] = useState<boolean>(false);
+  const [volumesFilter, setVolumesFilter] = useState<VolumesFilterProps>({
+    myVolumes: false,
+    query: "",
+    by: VolumeFilterBy.NAME,
+  });
+
+  async function updateVolumes() {
+    try {
+      setVolumesAreLoading(true);
+      const nextVolumes = await getVolumesApi();
+      setVolumes(nextVolumes ?? []);
+    } catch (error) {
+      console.error("Error fetching volumes:", error);
+    } finally {
+      setVolumesAreLoading(false);
+    }
+  }
+
+  async function createVolume(volume: ManagedVolumeCreateRequest) {
+    try {
+      await createVolumesApi(volume);
+      alert.success("Volume created successfully");
+    } catch (error) {
+      console.error(error);
+      alert.error("Error creating volume");
+    }
+
+    await updateVolumes();
+  }
+
+  async function deleteVolume(volumeName: string) {
+    try {
+      await deleteVolumesApi(volumeName);
+      alert.success("Volume deleted successfully");
+    } catch (error) {
+      console.error(error);
+      alert.error("Error deleting volume");
+    }
+
+    await updateVolumes();
+  }
+
+  return (
+    <VolumesContext.Provider
+      value={{
+        volumesFilter,
+        setVolumesFilter,
+        volumes,
+        volumesAreLoading,
+        setVolumes,
+        updateVolumes,
+        createVolume,
+        deleteVolume,
+      }}
+    >
+      {children}
+    </VolumesContext.Provider>
+  );
+};
+
+export function useVolumes() {
+  return useContext(VolumesContext);
+}

--- a/src/contexts/Volumes/VolumesContext.tsx
+++ b/src/contexts/Volumes/VolumesContext.tsx
@@ -7,6 +7,7 @@ import {
   ManagedVolume,
   ManagedVolumeCreateRequest,
 } from "@/pages/ui/services/models/service";
+import { errorMessage } from "@/lib/error";
 
 interface VolumesFilterProps {
   myVolumes: boolean;
@@ -25,6 +26,7 @@ export type VolumesProviderData = {
   setVolumesFilter: (filter: VolumesFilterProps) => void;
   volumes: ManagedVolume[];
   volumesAreLoading: boolean;
+  volumesLoadingError: boolean;
   setVolumes: (volumes: ManagedVolume[]) => void;
   updateVolumes: () => Promise<void>;
   createVolume: (volume: ManagedVolumeCreateRequest) => Promise<void>;
@@ -40,6 +42,7 @@ export const VolumesProvider = ({
 }) => {
   const [volumes, setVolumes] = useState<ManagedVolume[]>([]);
   const [volumesAreLoading, setVolumesAreLoading] = useState<boolean>(false);
+  const [volumesLoadingError, setVolumesLoadingError] = useState<boolean>(false);
   const [volumesFilter, setVolumesFilter] = useState<VolumesFilterProps>({
     myVolumes: false,
     query: "",
@@ -48,11 +51,14 @@ export const VolumesProvider = ({
 
   async function updateVolumes() {
     try {
+      setVolumesLoadingError(false);
       setVolumesAreLoading(true);
       const nextVolumes = await getVolumesApi();
       setVolumes(nextVolumes ?? []);
     } catch (error) {
       console.error("Error fetching volumes:", error);
+      alert.error(`Error fetching volumes: ${errorMessage(error)}`);
+      setVolumesLoadingError(true);
     } finally {
       setVolumesAreLoading(false);
     }
@@ -89,6 +95,7 @@ export const VolumesProvider = ({
         setVolumesFilter,
         volumes,
         volumesAreLoading,
+        volumesLoadingError,
         setVolumes,
         updateVolumes,
         createVolume,

--- a/src/contexts/Volumes/VolumesContext.tsx
+++ b/src/contexts/Volumes/VolumesContext.tsx
@@ -54,7 +54,7 @@ export const VolumesProvider = ({
       setVolumesLoadingError(false);
       setVolumesAreLoading(true);
       const nextVolumes = await getVolumesApi();
-      setVolumes(nextVolumes ?? []);
+      setVolumes(nextVolumes.managed_volume ?? []);
     } catch (error) {
       console.error("Error fetching volumes:", error);
       alert.error(`Error fetching volumes: ${errorMessage(error)}`);

--- a/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
+++ b/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
@@ -11,7 +11,6 @@ import { alert } from "@/lib/alert";
 import { generateReadableName, genRandomString, getAllowedVOs } from "@/lib/utils";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
 import {
-  Bucket,
   ManagedVolume,
   Service,
 } from "@/pages/ui/services/models/service";

--- a/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
+++ b/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
@@ -1,4 +1,5 @@
 import createServiceApi from "@/api/services/createServiceApi";
+import getVolumesApi from "@/api/volumes/getVolumesApi";
 import RequestButton from "@/components/RequestButton";
 import { Button, ButtonProps } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
@@ -9,7 +10,11 @@ import { useAuth } from "@/contexts/AuthContext";
 import { alert } from "@/lib/alert";
 import { generateReadableName, genRandomString, getAllowedVOs } from "@/lib/utils";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
-import { Service } from "@/pages/ui/services/models/service";
+import {
+  Bucket,
+  ManagedVolume,
+  Service,
+} from "@/pages/ui/services/models/service";
 import { RefreshCcwIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { RoCrateServiceDefinition } from "@/lib/roCrate";
@@ -35,7 +40,40 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
 
   const oidcGroups = getAllowedVOs(systemConfig, authData);
 	const asyncService = roCrateServiceDef.type.some(t => t.toLowerCase() === "asynchronous");
-	const mountBucket = service?.mount;
+  const mountBucket = service?.mount;
+  const serviceVolume = service?.volume;
+  const canCreateManagedVolume = !!serviceVolume;
+
+  function parseVolumeSize(size?: string): string {
+    if (!size) {
+      return "1";
+    }
+
+    const parsedSize = size.trim().match(/^(\d+(?:\.\d+)?)(Mi|Gi)$/);
+
+    if (!parsedSize) {
+      return "1";
+    }
+
+    const numericSize = Number(parsedSize[1]);
+    const unit = parsedSize[2];
+
+    if (unit === "Mi") {
+      return String(numericSize / 1024);
+    }
+
+    return parsedSize[1];
+  }
+
+  function isValidVolumeSize(value: string): boolean {
+    const trimmedValue = value.trim();
+
+    if (!/^\d+(\.\d+)?$/.test(trimmedValue)) {
+      return false;
+    }
+
+    return Number(trimmedValue) > 0;
+  }
 
   function nameService() {
     return `hub-${generateReadableName(6)}-${genRandomString(8).toLowerCase()}`;
@@ -47,14 +85,21 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
     memoryRam: "2",
     memoryUnit: "Gi",
     bucket: "",
+    volume: "",
+    volumeSize: "1",
     vo: "",
     token: "",
     enviromentVars: {} as Record<string, string>,
     enviromentSecrets: {} as Record<string, string>,
   });
+  const [newVolume, setNewVolume] = useState(false);
+  const [volumes, setVolumes] = useState<ManagedVolume[]>([]);
 
   function ifEndpointService(key: string, value: string, serviceName: string): string {
-    const newValue = value.replace(/\/services\/([^\/]+)\/exposed/, `/services/${serviceName}/exposed`);
+    const newValue = value.replace(
+      /\/services\/([^/]+)\/exposed/,
+      `/services/${serviceName}/exposed`
+    );
     if (newValue.includes(`/services/${serviceName}/exposed`)) {
       formData.enviromentVars = {
         ...formData.enviromentVars,
@@ -69,6 +114,8 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
     cpuCores: false,
     memoryRam: false,
     bucket: false,
+    volume: false,
+    volumeSize: false,
     vo: false,
     token: false,
     enviromentVars: {} as Record<string, boolean>,
@@ -84,6 +131,7 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
   useEffect(() => {
     if (!isOpen) return;
 
+    const initialVolume = serviceVolume?.name || "";
     setFormData((prev) => ({
       ...prev, 
       name: nameService(),
@@ -91,28 +139,83 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
       memoryRam: roCrateServiceDef.memoryRequirements,
       memoryUnit: roCrateServiceDef.memoryUnits,
       bucket: "",
+      volume: "",
+      volumeSize: parseVolumeSize(serviceVolume?.size),
       token: genRandomString(128),
       enviromentVars: service.environment?.variables || {},
       enviromentSecrets: service.environment?.secrets || {},
     }));
+    setNewBucket(false);
+    setVolumes([]);
+    setNewVolume(false);
     setErrors({
       name: false,
       cpuCores: false,
       memoryRam: false,
       bucket: false,
+      volume: false,
+      volumeSize: false,
       vo: false,
       token: false,
       enviromentVars: {} as Record<string, boolean>,
       enviromentSecrets: {} as Record<string, boolean>,
     });
-  }, [isOpen]);
+
+    let cancelled = false;
+
+    const loadVolumes = async () => {
+      if (!serviceVolume) return;
+
+      try {
+        const nextVolumes = await getVolumesApi();
+        if (cancelled) return;
+
+        const volumeExists = nextVolumes.some(
+          (volume) => volume.name === initialVolume
+        );
+
+        setVolumes(nextVolumes);
+        setNewVolume(nextVolumes.length === 0);
+        setFormData((prev) => ({
+          ...prev,
+          volume:
+            nextVolumes.length === 0
+              ? initialVolume
+              : volumeExists
+                ? initialVolume
+                : "",
+        }));
+      } catch (error) {
+        if (cancelled) return;
+        console.log(error);
+        setVolumes([]);
+        setNewVolume(true);
+        setFormData((prev) => ({
+          ...prev,
+          volume: initialVolume,
+        }));
+        alert.error("Error loading volumes");
+      }
+    };
+
+    void loadVolumes();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, roCrateServiceDef, service, serviceVolume]);
 
   const handleDeploy = async () => {
     const newErrors = {
       name: !formData.name,
       cpuCores: !formData.cpuCores,
       memoryRam: !formData.memoryRam,
-      bucket: !formData.bucket && asyncService,
+      bucket: !formData.bucket && (asyncService || !!mountBucket),
+      volume: !formData.volume && !!serviceVolume,
+      volumeSize:
+        !!serviceVolume &&
+        newVolume &&
+        !isValidVolumeSize(formData.volumeSize),
       vo: !formData.vo,
       token: !formData.token,
       enviromentVars: Object.fromEntries(Object.entries(formData.enviromentVars).map(([key, value]) => [key, !value || value.length === 0])),
@@ -138,6 +241,19 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
       service.script = scriptText
       const serviceName = formData.name || nameService();
 
+      const serviceVolumeConfig = serviceVolume
+        ? newVolume
+          ? {
+              ...serviceVolume,
+              name: formData.volume,
+              size: `${formData.volumeSize.trim()}Gi`,
+            }
+          : {
+              name: formData.volume,
+              mount_path: serviceVolume.mount_path,
+            }
+        : undefined;
+
       const modifiedService: Service = {
         ...service,
         name: serviceName,
@@ -162,6 +278,7 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
           storage_provider: "minio.default",
           path: formData.bucket,
         } : undefined,
+        volume: serviceVolumeConfig,
         environment: {
           ...service.environment,
           variables: {
@@ -186,12 +303,6 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
       alert.error(`Error deploying ${roCrateServiceDef.name} instance: ${errorMessage(error)}`);
     }
   };
-
-  useEffect(() => {
-    if (oidcGroups.length) {
-      setFormData({ ...formData, vo: oidcGroups[0] });
-    }
-  }, [oidcGroups.length]);  
 
 return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -309,49 +420,171 @@ return (
             </div>
 						{(asyncService || mountBucket) && 
             <div>
-              <Label className="inline-flex items-center cursor-pointer">
-                <input type="checkbox" value="" checked={newBucket || asyncService} disabled={asyncService} className="sr-only peer" onClick={() => { setNewBucket(!newBucket); setFormData({ ...formData, bucket: "" }); }} />
-                <div className="relative w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-teal-600 dark:peer-checked:bg-teal-600 peer-disabled:opacity-60 peer-disabled:cursor-not-allowed"></div>
-                <span className="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300 peer-disabled:cursor-default">New Bucket</span>
-              </Label>
-              {newBucket || !mountBucket ? 
+              <Label>Bucket</Label>
+              <hr className="mb-2"/>
+              <div>
+                <Label className="inline-flex items-center cursor-pointer">
+                  <input
+                    type="checkbox"
+                    value=""
+                    className="sr-only peer"
+                    checked={newBucket || asyncService}
+                    disabled={asyncService}
+                    onChange={() => {
+                      setNewBucket((prev) => !prev);
+                      setFormData((prev) => ({
+                        ...prev,
+                        bucket: "",
+                      }));
+                    }}
+                  />
+                  <div className="relative w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-teal-600 dark:peer-checked:bg-teal-600 peer-disabled:opacity-60 peer-disabled:cursor-not-allowed"></div>
+                  <span className="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300 peer-disabled:cursor-default">New Bucket</span>
+                </Label>
+                {newBucket || !mountBucket ? 
                 <Input
                   type="input"
                   onFocus={(e) => (e.target.type = "text")}
                   style={{ width: "100%",
                     fontWeight: "normal",
                     }}
+                  value={formData.bucket}
                   className={errors.bucket ? "border-red-500 focus:border-red-500" : ""}
                   onChange={(e) => {
-                      setFormData({ ...formData, bucket: e.target?.value });
-                      if (errors.bucket) setErrors({ ...errors, bucket: false });
+                    setFormData({ ...formData, bucket: e.target?.value });
+                    if (errors.bucket) {
+                      setErrors({ ...errors, bucket: false });
+                    }
                   }}
                   placeholder="Enter new bucket name"
                 />
-              :
-                <Select
-                  value={formData.bucket}
-                  onValueChange={(value) => {
-                    setFormData({ ...formData, bucket: value });
-                    if (errors.bucket) setErrors({ ...errors, bucket: false });
-                  }}
-                >
-                  <SelectTrigger className={errors.bucket ? "border-red-500 focus:border-red-500" : ""}>
-                    <SelectValue
-                      placeholder="Select a bucket"
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {buckets.map((bucket) => (
-                      <SelectItem key={bucket.bucket_name} value={bucket.bucket_name}>
-                        {bucket.bucket_name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              }
+                :
+                  <Select
+                    value={formData.bucket}
+                    onValueChange={(value) => {
+                      setFormData({ ...formData, bucket: value });
+                      if (errors.bucket) {
+                        setErrors({ ...errors, bucket: false });
+                      }
+                    }}
+                  >
+                    <SelectTrigger className={errors.bucket ? "border-red-500 focus:border-red-500" : ""}>
+                      <SelectValue
+                        placeholder="Select a bucket"
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {buckets.map((bucket) => (
+                        <SelectItem
+                          key={bucket.bucket_name}
+                          value={bucket.bucket_name}
+                        >
+                          {bucket.bucket_name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                }
+              </div>
             </div>
 						}
+            {serviceVolume &&
+            <div>
+              <Label>Volume</Label>
+              <hr className="mb-2"/>
+              <div>
+                {canCreateManagedVolume && (
+                  <Label className="inline-flex items-center cursor-pointer">
+                    <input
+                      type="checkbox"
+                      value=""
+                      className="sr-only peer"
+                      checked={newVolume}
+                      onChange={() => {
+                        setNewVolume((prev) => !prev);
+                        setFormData((prev) => ({
+                          ...prev,
+                          volume: "",
+                          volumeSize: parseVolumeSize(serviceVolume.size),
+                        }));
+                      }}
+                    />
+                    <div className="relative w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-teal-600 dark:peer-checked:bg-teal-600"></div>
+                    <span className="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">New Volume</span>
+                  </Label>
+                )}
+                {newVolume ? 
+                <div className="grid gap-2">
+                  <Input
+                    type="input"
+                    onFocus={(e) => (e.target.type = "text")}
+                    style={{ width: "100%",
+                      fontWeight: "normal",
+                      }}
+                    value={formData.volume}
+                    className={errors.volume ? "border-red-500 focus:border-red-500" : ""}
+                    onChange={(e) => {
+                      setFormData({ ...formData, volume: e.target?.value });
+                      if (errors.volume) {
+                        setErrors({ ...errors, volume: false });
+                      }
+                    }}
+                    placeholder="Enter new volume name"
+                  />
+                  <div className="grid gap-1">
+                    <Label htmlFor="volumeSize">Volume size (Gi)</Label>
+                    <Input
+                      id="volumeSize"
+                      type="number"
+                      min="0.1"
+                      step="any"
+                      inputMode="decimal"
+                      value={formData.volumeSize}
+                      className={`max-w-[180px] ${
+                        errors.volumeSize
+                          ? "border-red-500 focus:border-red-500"
+                          : ""
+                      }`}
+                      onChange={(e) => {
+                        setFormData({
+                          ...formData,
+                          volumeSize: e.target.value,
+                        });
+                        if (errors.volumeSize) {
+                          setErrors({ ...errors, volumeSize: false });
+                        }
+                      }}
+                      placeholder="1"
+                    />
+                  </div>
+                </div>
+                :
+                  <Select
+                    value={formData.volume}
+                    onValueChange={(value) => {
+                      setFormData({ ...formData, volume: value });
+                      if (errors.volume) {
+                        setErrors({ ...errors, volume: false });
+                      }
+                    }}
+                  >
+                    <SelectTrigger className={errors.volume ? "border-red-500 focus:border-red-500" : ""}>
+                      <SelectValue
+                        placeholder="Select a volume"
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {volumes.map((volume) => (
+                        <SelectItem key={volume.name} value={volume.name}>
+                          {volume.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                }
+              </div>
+            </div>
+            }
             {formData?.enviromentVars && Object.entries(formData.enviromentVars).map(([key, value]) => (
             <div key={`var-${key}`}>
               <Label>{key}</Label>

--- a/src/pages/ui/hub/components/HubSrcPopoverButton/index.tsx
+++ b/src/pages/ui/hub/components/HubSrcPopoverButton/index.tsx
@@ -1,7 +1,11 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Check, FolderGit2, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -10,17 +14,24 @@ export interface GitHubSource {
   branch: string;
 }
 
-export function equalSources(source1: GitHubSource, source2: GitHubSource): boolean {
-  return source1.repository === source2.repository && source1.branch === source2.branch;
+export function equalSources(
+  source1: GitHubSource,
+  source2: GitHubSource
+): boolean {
+  return (
+    source1.repository === source2.repository &&
+    source1.branch === source2.branch
+  );
 }
 
 const OSCAR_HUB_SOURCES_KEY = "oscar_hub_sources";
 const OSCAR_HUB_SELECTED_SOURCE_KEY = "oscar_hub_selected_source";
+
 export const DEFAULT_SOURCES = [
-  { repository: "grycap/oscar-hub", branch: "main" }
+  { repository: "grycap/oscar-hub", branch: "main" },
 ];
 
-function HubSrcPopoverButton( {
+function HubSrcPopoverButton({
   responsiveButton = "sm",
   variant,
   className,
@@ -28,7 +39,17 @@ function HubSrcPopoverButton( {
   setSelectedSource,
 }: {
   responsiveButton?: "none" | "sm" | "md" | "lg";
-  variant?: "link" | "default" | "destructive" | "outline" | "secondary" | "ghost" | "mainGreen" | "lightGreen" | null | undefined;
+  variant?:
+    | "link"
+    | "default"
+    | "destructive"
+    | "outline"
+    | "secondary"
+    | "ghost"
+    | "mainGreen"
+    | "lightGreen"
+    | null
+    | undefined;
   className?: string;
   selectedSource: GitHubSource;
   setSelectedSource: (source: GitHubSource) => void;
@@ -38,59 +59,108 @@ function HubSrcPopoverButton( {
   const [newRepo, setNewRepo] = useState("");
   const [newBranch, setNewBranch] = useState("");
 
-  const newRepoFormatError: boolean = !!newRepo && ( !newRepo.trim().startsWith("https://github.com/") || newRepo.trim().replace("https://github.com/", "").length <= 0 );
+  const newRepoFormatError =
+    !!newRepo &&
+    (!newRepo.trim().startsWith("https://github.com/") ||
+      newRepo.trim().replace("https://github.com/", "").length <= 0);
 
   useEffect(() => {
     try {
-      const storedSource = localStorage.getItem(OSCAR_HUB_SELECTED_SOURCE_KEY);
-      setSelectedSource(storedSource ? JSON.parse(storedSource) : DEFAULT_SOURCES[0]);
+      const storedSource = localStorage.getItem(
+        OSCAR_HUB_SELECTED_SOURCE_KEY
+      );
+      setSelectedSource(
+        storedSource ? JSON.parse(storedSource) : DEFAULT_SOURCES[0]
+      );
     } catch (error) {
       if (error instanceof SyntaxError) {
-        console.error("Error parsing OSCAR HUB selected source from localStorage, processing to reset to default source:", error);
-        localStorage.setItem(OSCAR_HUB_SELECTED_SOURCE_KEY, JSON.stringify(DEFAULT_SOURCES[0]));
+        console.error(
+          "Error parsing OSCAR HUB selected source from localStorage. " +
+            "Resetting to default source:",
+          error
+        );
+        localStorage.setItem(
+          OSCAR_HUB_SELECTED_SOURCE_KEY,
+          JSON.stringify(DEFAULT_SOURCES[0])
+        );
         setSelectedSource(DEFAULT_SOURCES[0]);
       }
     }
 
     try {
       const storedSources = localStorage.getItem(OSCAR_HUB_SOURCES_KEY);
-      const parsedSources: GitHubSource[] = storedSources ? JSON.parse(storedSources) : [];
-      const uniqueSources = parsedSources.filter((source) => !DEFAULT_SOURCES.find((defaultSource) => equalSources(defaultSource, source)));
+      const parsedSources: GitHubSource[] = storedSources
+        ? JSON.parse(storedSources)
+        : [];
+      const uniqueSources = parsedSources.filter(
+        (source) =>
+          !DEFAULT_SOURCES.find((defaultSource) =>
+            equalSources(defaultSource, source)
+          )
+      );
       setSources([...DEFAULT_SOURCES, ...uniqueSources]);
     } catch (error) {
       if (error instanceof SyntaxError) {
-        console.error("Error parsing OSCAR HUB sources from localStorage, processing to reset to default sources:", error);
-        localStorage.setItem(OSCAR_HUB_SOURCES_KEY, JSON.stringify(DEFAULT_SOURCES));
+        console.error(
+          "Error parsing OSCAR HUB sources from localStorage. " +
+            "Resetting to defaults:",
+          error
+        );
+        localStorage.setItem(
+          OSCAR_HUB_SOURCES_KEY,
+          JSON.stringify(DEFAULT_SOURCES)
+        );
         setSources(DEFAULT_SOURCES);
       }
     }
-  }, []);
+  }, [setSelectedSource]);
 
   function removeSource(sourceToRemove: GitHubSource): void {
-    const updatedSources = sources.filter((source) => !equalSources(source, sourceToRemove));
+    const updatedSources = sources.filter(
+      (source) => !equalSources(source, sourceToRemove)
+    );
     setSources(updatedSources);
-    localStorage.setItem(OSCAR_HUB_SOURCES_KEY, JSON.stringify(updatedSources));
+    localStorage.setItem(
+      OSCAR_HUB_SOURCES_KEY,
+      JSON.stringify(updatedSources)
+    );
+
     if (!updatedSources.find((source) => equalSources(source, selectedSource))) {
       setSelectedSource(DEFAULT_SOURCES[0]);
-      localStorage.setItem(OSCAR_HUB_SELECTED_SOURCE_KEY, JSON.stringify(DEFAULT_SOURCES[0]));
+      localStorage.setItem(
+        OSCAR_HUB_SELECTED_SOURCE_KEY,
+        JSON.stringify(DEFAULT_SOURCES[0])
+      );
     }
   }
 
   function selectSource(source: GitHubSource): void {
     setSelectedSource(source);
-    localStorage.setItem(OSCAR_HUB_SELECTED_SOURCE_KEY, JSON.stringify(source));
+    localStorage.setItem(
+      OSCAR_HUB_SELECTED_SOURCE_KEY,
+      JSON.stringify(source)
+    );
   }
 
   function addSource(): void {
     const trimmedRepo = newRepo.trim().replace("https://github.com/", "");
     const trimmedBranch = newBranch.trim();
+
     if (!trimmedRepo || !trimmedBranch || newRepoFormatError) return;
 
-    const newSource: GitHubSource = { repository: trimmedRepo, branch: trimmedBranch };
-    if (sources.find((s) => equalSources(s, newSource))) return;
+    const newSource: GitHubSource = {
+      repository: trimmedRepo,
+      branch: trimmedBranch,
+    };
+
+    if (sources.find((source) => equalSources(source, newSource))) return;
+
     const updatedSources = [...sources, newSource];
     setSources(updatedSources);
-    localStorage.setItem(OSCAR_HUB_SOURCES_KEY, JSON.stringify(updatedSources));
+    localStorage.setItem(
+      OSCAR_HUB_SOURCES_KEY,
+      JSON.stringify(updatedSources)
+    );
     setNewRepo("");
     setNewBranch("");
   }
@@ -107,15 +177,28 @@ function HubSrcPopoverButton( {
       }}
     >
       <PopoverTrigger asChild>
-        <Button 
-					className={className}
+        <Button
+          className={className}
           variant={variant}
-          tooltipLabel={"Manage sources"}
-          onClick={() => {setIsOpen(!isOpen)}}
-          style={{gap: 8}} 
+          tooltipLabel="Manage sources"
+          onClick={() => {
+            setIsOpen(!isOpen);
+          }}
+          style={{ gap: 8 }}
         >
           <FolderGit2 size={20} className="h-5 w-5" />
-          <span className={{ none: "", sm: "hidden sm:inline", md: "hidden md:inline", lg: "hidden lg:inline" }[responsiveButton]}>Manage Sources</span>
+          <span
+            className={
+              {
+                none: "",
+                sm: "hidden sm:inline",
+                md: "hidden md:inline",
+                lg: "hidden lg:inline",
+              }[responsiveButton]
+            }
+          >
+            Manage Sources
+          </span>
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-80" align="center">
@@ -128,11 +211,12 @@ function HubSrcPopoverButton( {
             {sources.map((source, index) => (
               <div
                 key={index}
-                className={`flex items-center justify-between gap-3 rounded border px-3 py-2 cursor-pointer ${
-                  equalSources(selectedSource, source)
-                    ? "border-[#009688] bg-[#009688]/10"
-                    : "hover:bg-slate-100 dark:hover:bg-slate-800"
-                }`}
+                className={`flex items-center justify-between gap-3 rounded
+                  border px-3 py-2 cursor-pointer ${
+                    equalSources(selectedSource, source)
+                      ? "border-[#009688] bg-[#009688]/10"
+                      : "hover:bg-slate-100 dark:hover:bg-slate-800"
+                  }`}
                 onClick={() => selectSource(source)}
               >
                 <div className="flex items-center gap-2 min-w-0">
@@ -144,16 +228,25 @@ function HubSrcPopoverButton( {
                     }`}
                   />
                   <div className="min-w-0">
-                    <div className="truncate font-medium text-sm">{source.repository}</div>
-                    <div className="text-xs text-muted-foreground">{source.branch}</div>
+                    <div className="truncate font-medium text-sm">
+                      {source.repository}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {source.branch}
+                    </div>
                   </div>
                 </div>
-                {!DEFAULT_SOURCES.includes(source) && (
+                {!DEFAULT_SOURCES.find((defaultSource) =>
+                  equalSources(defaultSource, source)
+                ) && (
                   <Button
                     className="hover:bg-red-100 dark:hover:bg-red-950"
                     variant="ghost"
                     size="icon"
-                    onClick={(e) => { e.stopPropagation(); removeSource(source); }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      removeSource(source);
+                    }}
                     aria-label={`Remove ${source.repository}`}
                   >
                     <Trash2 className="h-4 w-4" color="red" />
@@ -163,35 +256,42 @@ function HubSrcPopoverButton( {
             ))}
           </div>
           <p className="border-t pt-3 text-sm font-medium">Add source</p>
-          <div className="">
+          <div>
             <div className="flex flex-col gap-2">
               <div className="flex flex-col gap-1">
-                <Label htmlFor="new-repo" className="text-xs">Repository</Label>
+                <Label htmlFor="new-repo" className="text-xs">
+                  Repository
+                </Label>
                 <Input
                   id="new-repo"
                   placeholder="https://github.com/owner/repo"
                   value={newRepo}
                   onChange={(e) => setNewRepo(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") addSource(); }}
-                  className={`${
-                    newRepoFormatError ? "border-red-500" : ""
-                  }`}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") addSource();
+                  }}
+                  className={newRepoFormatError ? "border-red-500" : ""}
                 />
                 {newRepoFormatError && (
-                  <span className="text-xs text-red-500">Please enter a valid GitHub repository URL.</span>
+                  <span className="text-xs text-red-500">
+                    Please enter a valid GitHub repository URL.
+                  </span>
                 )}
               </div>
               <div className="flex flex-col gap-1">
-                <Label htmlFor="new-branch" className="text-xs">Branch</Label>
+                <Label htmlFor="new-branch" className="text-xs">
+                  Branch
+                </Label>
                 <Input
                   id="new-branch"
                   placeholder="main"
                   value={newBranch}
                   onChange={(e) => setNewBranch(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") addSource(); }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") addSource();
+                  }}
                 />
               </div>
-              
             </div>
           </div>
           <div className="flex justify-end space-x-2">
@@ -199,7 +299,9 @@ function HubSrcPopoverButton( {
               variant="lightGreen"
               className="w-full"
               onClick={addSource}
-              disabled={!newRepo.trim() || !newBranch.trim() || newRepoFormatError}
+              disabled={
+                !newRepo.trim() || !newBranch.trim() || newRepoFormatError
+              }
             >
               <Plus className="h-4 w-4 mr-1" />
               Add

--- a/src/pages/ui/hub/index.tsx
+++ b/src/pages/ui/hub/index.tsx
@@ -56,7 +56,6 @@ function HubView() {
     setIsLoading(true);
     const repoOwner = selectedSource.repository.split("/")[0];
     const repoName = selectedSource.repository.split("/")[1];
-    const roCrateServices = await parseROCrateDataJS(repoOwner, repoName, selectedSource.branch);
     const roCrateServices = await parseROCrateDataJS(
       repoOwner,
       repoName,
@@ -181,7 +180,6 @@ function HubView() {
       }
       >
         <div className="flex flex-row items-center w-full justify-end gap-2">
-          <HubSrcPopoverButton variant="mainGreen" selectedSource={selectedSource} setSelectedSource={setSelectedSource} />
           <HubSrcPopoverButton
             variant="mainGreen"
             selectedSource={selectedSource}

--- a/src/pages/ui/hub/index.tsx
+++ b/src/pages/ui/hub/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import HubCard from "./components/HubCard/index";
 import parseROCrateDataJS, { RoCrateServiceDefinition } from "@/lib/roCrate";
 import { Input } from "@/components/ui/input";
@@ -25,11 +25,43 @@ function HubView() {
   const [isGridView, setIsGridView] = useState(true);
   const [selectedSource, setSelectedSource] = useState<GitHubSource>(DEFAULT_SOURCES[0]);
 
-  async function fetchData() {
+  const fetchService = useCallback(
+    async (
+      roCrateServiceDef: RoCrateServiceDefinition
+    ): Promise<Service | undefined> => {
+      const response = await fetch(roCrateServiceDef.fdlUrl);
+      if (response.ok) {
+        const service = yamlToServices(await response.text(), "")![0];
+        const services: Service = {
+          ...service,
+          environment: {
+            ...service.environment,
+            secrets: Object.fromEntries(
+              Object.entries(service.environment?.secrets || {}).map(
+                ([key]) => {
+                  return [key, ""];
+                }
+              )
+            ),
+          },
+        };
+        return services;
+      }
+      return undefined;
+    },
+    []
+  );
+
+  const fetchData = useCallback(async () => {
     setIsLoading(true);
     const repoOwner = selectedSource.repository.split("/")[0];
     const repoName = selectedSource.repository.split("/")[1];
     const roCrateServices = await parseROCrateDataJS(repoOwner, repoName, selectedSource.branch);
+    const roCrateServices = await parseROCrateDataJS(
+      repoOwner,
+      repoName,
+      selectedSource.branch
+    );
     let i = 0;
     const services: Record<string, [RoCrateServiceDefinition, Service]> = {};
     for (const roCrateServiceDef of roCrateServices) {
@@ -40,44 +72,32 @@ function HubView() {
     setServiceDefinitions(services);
     setFilteredServices(services);
     setIsLoading(false);
-  }
-
-  async function fetchService(roCrateServiceDef: RoCrateServiceDefinition): Promise<Service | undefined> {
-    const response = await fetch(roCrateServiceDef.fdlUrl);
-    if (response.ok) {
-      const service = yamlToServices(await response.text(), "")![0];
-      const services: Service = {
-        ...service,
-        environment: {
-          ...service.environment,
-          secrets: Object.fromEntries(Object.entries(service.environment?.secrets || {}).map(([key, _]) => {
-            return [key, ''];
-          })),
-        },
-      };
-      return services;
-    }
-    return undefined;
-  }
+  }, [fetchService, selectedSource]);
 
   useEffect(() => {
     document.title ="OSCAR - Hub"
   }, []);
 
-  useMemo(() => {
-    fetchData();
-  }, [selectedSource]);
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
 
   // Filter services based on search query
   useEffect(() => {
     if (!searchQuery.trim() && !filter.serviceType) {
       setFilteredServices(serviceDefinitions);
     } else {
-      const filtered = Object.entries(serviceDefinitions).filter(([, [roCrateServiceDef, _]]) => {
+      const filtered = Object.entries(serviceDefinitions).filter(([
+        ,
+        [roCrateServiceDef],
+      ]) => {
         const query = searchQuery.toLowerCase();
         return (
-          roCrateServiceDef.name.toLowerCase().includes(query) && 
-          (!filter.serviceType || roCrateServiceDef.type.some(type => type === filter.serviceType))
+          roCrateServiceDef.name.toLowerCase().includes(query) &&
+          (!filter.serviceType ||
+            roCrateServiceDef.type.some(
+              (type) => type === filter.serviceType
+            ))
         );
       });
       setFilteredServices(Object.fromEntries(filtered));
@@ -162,6 +182,11 @@ function HubView() {
       >
         <div className="flex flex-row items-center w-full justify-end gap-2">
           <HubSrcPopoverButton variant="mainGreen" selectedSource={selectedSource} setSelectedSource={setSelectedSource} />
+          <HubSrcPopoverButton
+            variant="mainGreen"
+            selectedSource={selectedSource}
+            setSelectedSource={setSelectedSource}
+          />
         </div>
       </GenericTopbar>
       <div className={`grid grid-cols-1 gap-6 ${isGridView ? `w-[95%] max-w-[1600px]` : 'w-full'} mx-auto mt-4 min-w-[300px] content-start`}>

--- a/src/pages/ui/services/models/service.ts
+++ b/src/pages/ui/services/models/service.ts
@@ -134,6 +134,11 @@ export enum Bucket_visibility {
   public = "public",
 }
 
+export interface Volumes {
+  volume_limits: VolumeLimits;
+  managed_volume: ManagedVolume[];
+}
+
 export interface VolumeStatus {
   phase?: string;
   message?: string;
@@ -143,6 +148,13 @@ export interface VolumeStatus {
 export interface VolumeAttachmentReference {
   service_name: string;
   mount_path: string;
+}
+
+export interface VolumeLimits {
+  disk_available: number;
+  max_volumes: string;
+  max_disk_per_volume: string;
+  min_disk_per_volume: string;
 }
 
 export interface ManagedVolume {

--- a/src/pages/ui/services/models/service.ts
+++ b/src/pages/ui/services/models/service.ts
@@ -134,6 +134,42 @@ export enum Bucket_visibility {
   public = "public",
 }
 
+export interface VolumeStatus {
+  phase?: string;
+  message?: string;
+  attachment_count?: number;
+}
+
+export interface VolumeAttachmentReference {
+  service_name: string;
+  mount_path: string;
+}
+
+export interface ManagedVolume {
+  name: string;
+  namespace?: string;
+  pvc_name?: string;
+  size?: string;
+  owner_user?: string;
+  created_by_service?: string;
+  creation_mode?: string;
+  lifecycle_policy?: string;
+  attachments?: VolumeAttachmentReference[];
+  status: VolumeStatus;
+}
+
+export interface ManagedVolumeCreateRequest {
+  name: string;
+  size: string;
+}
+
+export interface ServiceVolumeConfig {
+  name?: string;
+  size?: string;
+  mount_path: string;
+  lifecycle_policy?: string;
+}
+
 export interface Service {
   allowed_users: string[];
   name: string;
@@ -170,6 +206,7 @@ export interface Service {
     path: string;
     storage_provider: string;
   };
+  volume?: ServiceVolumeConfig;
   expose: {
     min_scale: string,
     max_scale: string,

--- a/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
+++ b/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
@@ -44,27 +44,6 @@ const TERMINAL_FDL_URL =
 const TERMINAL_SCRIPT_URL =
   "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/ghostty-web/script.sh";
 
-function parseVolumeSize(size?: string): string {
-  if (!size) {
-    return "1";
-  }
-
-  const parsedSize = size.trim().match(/^(\d+(?:\.\d+)?)(Mi|Gi)$/);
-
-  if (!parsedSize) {
-    return "1";
-  }
-
-  const numericSize = Number(parsedSize[1]);
-  const unit = parsedSize[2];
-
-  if (unit === "Mi") {
-    return String(numericSize / 1024);
-  }
-
-  return parsedSize[1];
-}
-
 function isValidVolumeSize(value: string): boolean {
   const trimmedValue = value.trim();
 
@@ -77,9 +56,7 @@ function isValidVolumeSize(value: string): boolean {
 
 function TerminalFormPopover() {
   const [isOpen, setIsOpen] = useState(false);
-  const [mountBucket, setMountBucket] = useState(false);
   const [newBucket, setNewBucket] = useState(false);
-  const [mountVolume, setMountVolume] = useState(false);
   const [newVolume, setNewVolume] = useState(false);
   const [volumes, setVolumes] = useState<ManagedVolume[]>([]);
   const { systemConfig, authData } = useAuth();
@@ -107,13 +84,15 @@ function TerminalFormPopover() {
     vo: "",
     token: "",
   });
+  const bucketName = formData.bucket.trim();
+  const volumeName = formData.volume.trim();
+  const mountBucket = bucketName.length > 0;
+  const mountVolume = volumeName.length > 0;
 
   const [errors, setErrors] = useState({
     name: false,
     cpuCores: false,
     memoryRam: false,
-    bucket: false,
-    volume: false,
     volumeSize: false,
     vo: false,
   });
@@ -141,17 +120,13 @@ function TerminalFormPopover() {
       refreshToken: "",
       token: genRandomString(128),
     }));
-    setMountBucket(false);
     setNewBucket(false);
-    setMountVolume(false);
     setNewVolume(false);
     setVolumes([]);
     setErrors({
       name: false,
       cpuCores: false,
       memoryRam: false,
-      bucket: false,
-      volume: false,
       volumeSize: false,
       vo: false,
     });
@@ -173,21 +148,6 @@ function TerminalFormPopover() {
         }
 
         setVolumes(nextVolumes);
-
-        if (!mountVolume) {
-          return;
-        }
-
-        setNewVolume(nextVolumes.length === 0);
-        setFormData((prev) => ({
-          ...prev,
-          volume:
-            nextVolumes.length === 0
-              ? prev.volume
-              : nextVolumes.some((volume) => volume.name === prev.volume)
-                ? prev.volume
-                : "",
-        }));
       } catch (error) {
         if (cancelled) {
           return;
@@ -195,10 +155,6 @@ function TerminalFormPopover() {
 
         console.error(error);
         setVolumes([]);
-
-        if (mountVolume) {
-          setNewVolume(true);
-        }
       }
     };
 
@@ -207,15 +163,13 @@ function TerminalFormPopover() {
     return () => {
       cancelled = true;
     };
-  }, [isOpen, mountVolume]);
+  }, [isOpen]);
 
   const handleDeploy = async () => {
     const newErrors = {
       name: !formData.name,
       cpuCores: !formData.cpuCores,
       memoryRam: !formData.memoryRam,
-      bucket: mountBucket && !formData.bucket,
-      volume: mountVolume && !formData.volume,
       volumeSize:
         mountVolume && newVolume && !isValidVolumeSize(formData.volumeSize),
       vo: !formData.vo,
@@ -247,9 +201,9 @@ function TerminalFormPopover() {
       const service = services[0];
       const serviceName = formData.name || nameService();
       const workspaceDir = mountVolume
-        ? `/mnt/volumes/${formData.volume}`
+        ? `/mnt/volumes/${volumeName}`
         : mountBucket
-          ? `/mnt/${formData.bucket}`
+          ? `/mnt/${bucketName}`
           : `/tmp/${serviceName}`;
       const baseSecrets = Object.fromEntries(
         Object.entries(service.environment.secrets || {}).filter(
@@ -258,8 +212,8 @@ function TerminalFormPopover() {
       );
       const volumeConfig = mountVolume
         ? {
-            name: formData.volume,
-            mount_path: `/mnt/volumes/${formData.volume}`,
+            name: volumeName,
+            mount_path: `/mnt/volumes/${volumeName}`,
             ...(newVolume
               ? { size: `${formData.volumeSize.trim()}Gi` }
               : {}),
@@ -276,7 +230,7 @@ function TerminalFormPopover() {
         mount: mountBucket
           ? {
               ...service.mount,
-              path: formData.bucket,
+              path: bucketName,
               storage_provider:
                 service.mount?.storage_provider ?? "minio.default",
             }
@@ -472,249 +426,148 @@ function TerminalFormPopover() {
           <div>
             <Label>Bucket</Label>
             <hr className="mb-2" />
-            <Label className="inline-flex items-center cursor-pointer">
-              <input
-                type="checkbox"
-                value=""
-                checked={mountBucket}
-                className="sr-only peer"
-                onChange={() => {
-                  const nextMountBucket = !mountBucket;
-
-                  setMountBucket(nextMountBucket);
-                  setNewBucket(false);
-                  setFormData({
-                    ...formData,
-                    bucket: "",
-                  });
-
-                  if (errors.bucket) {
-                    setErrors({ ...errors, bucket: false });
-                  }
-                }}
-              />
-              <div className="relative w-9 h-5 bg-gray-200 rounded-full peer peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 peer-checked:bg-teal-600 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full after:absolute after:start-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-['']"></div>
-              <span className="ms-3 text-sm font-medium text-gray-900">
-                Mount bucket
-              </span>
-            </Label>
-            {mountBucket && (
-              <div className="mt-3">
-                <Label className="inline-flex items-center cursor-pointer">
-                  <input
-                    type="checkbox"
-                    value=""
-                    checked={newBucket}
-                    className="sr-only peer"
-                    onChange={() => {
-                      setNewBucket(!newBucket);
-                      setFormData({ ...formData, bucket: "" });
-
-                      if (errors.bucket) {
-                        setErrors({ ...errors, bucket: false });
-                      }
-                    }}
-                  />
-                  <div className="relative w-9 h-5 bg-gray-200 rounded-full peer peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 peer-checked:bg-teal-600 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full after:absolute after:start-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-['']"></div>
-                  <span className="ms-3 text-sm font-medium text-gray-900">
-                    New Bucket
-                  </span>
-                </Label>
-                <div className="mt-2">
-                  {newBucket ? (
-                    <Input
-                      type="input"
-                      onFocus={(e) => (e.target.type = "text")}
-                      style={{ width: "100%", fontWeight: "normal" }}
-                      className={
-                        errors.bucket
-                          ? "border-red-500 focus:border-red-500"
-                          : ""
-                      }
-                      onChange={(e) => {
-                        setFormData({ ...formData, bucket: e.target.value });
-                        if (errors.bucket) {
-                          setErrors({ ...errors, bucket: false });
-                        }
-                      }}
-                      placeholder="Enter new bucket name"
-                    />
-                  ) : (
-                    <Select
-                      value={formData.bucket}
-                      onValueChange={(value) => {
-                        setFormData({ ...formData, bucket: value });
-                        if (errors.bucket) {
-                          setErrors({ ...errors, bucket: false });
-                        }
-                      }}
-                    >
-                      <SelectTrigger
-                        className={
-                          errors.bucket
-                            ? "border-red-500 focus:border-red-500"
-                            : ""
-                        }
+            <div>
+              <Label className="inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  value=""
+                  checked={newBucket}
+                  className="sr-only peer"
+                  onClick={() => {
+                    setNewBucket(!newBucket);
+                    setFormData({ ...formData, bucket: "" });
+                  }}
+                >
+                </input>
+                <div className="relative w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-teal-600 dark:peer-checked:bg-teal-600"></div>
+                <span className="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">
+                  New Bucket
+                </span>
+              </Label>
+              {newBucket ? (
+                <Input
+                  type="input"
+                  onFocus={(e) => (e.target.type = "text")}
+                  style={{ width: "100%", fontWeight: "normal" }}
+                  value={formData.bucket}
+                  onChange={(e) => {
+                    setFormData({ ...formData, bucket: e.target.value });
+                  }}
+                  placeholder="Enter new bucket name"
+                />
+              ) : (
+                <Select
+                  value={formData.bucket}
+                  onValueChange={(value) => {
+                    setFormData({ ...formData, bucket: value });
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a bucket" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {buckets.map((bucket) => (
+                      <SelectItem
+                        key={bucket.bucket_name}
+                        value={bucket.bucket_name}
                       >
-                        <SelectValue placeholder="Select a bucket" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {buckets.map((bucket) => (
-                          <SelectItem
-                            key={bucket.bucket_name}
-                            value={bucket.bucket_name}
-                          >
-                            {bucket.bucket_name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  )}
-                </div>
-              </div>
-            )}
+                        {bucket.bucket_name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
           </div>
           <div>
             <Label>Volume</Label>
             <hr className="mb-2" />
-            <Label className="inline-flex items-center cursor-pointer">
-              <input
-                type="checkbox"
-                value=""
-                checked={mountVolume}
-                className="sr-only peer"
-                onChange={() => {
-                  const nextMountVolume = !mountVolume;
-                  const defaultNewVolume = nextMountVolume && volumes.length === 0;
-
-                  setMountVolume(nextMountVolume);
-                  setNewVolume(defaultNewVolume);
-                  setFormData({
-                    ...formData,
-                    volume: "",
-                    volumeSize: parseVolumeSize(),
-                  });
-
-                  if (errors.volume || errors.volumeSize) {
-                    setErrors({
-                      ...errors,
-                      volume: false,
-                      volumeSize: false,
+            <div>
+              <Label className="inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  value=""
+                  checked={newVolume}
+                  className="sr-only peer"
+                  onClick={() => {
+                    setNewVolume(!newVolume);
+                    setFormData({
+                      ...formData,
+                      volume: "",
+                      volumeSize: "1",
                     });
-                  }
-                }}
-              />
-              <div className="relative w-9 h-5 bg-gray-200 rounded-full peer peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 peer-checked:bg-teal-600 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full after:absolute after:start-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-['']"></div>
-              <span className="ms-3 text-sm font-medium text-gray-900">
-                Mount volume
-              </span>
-            </Label>
-            {mountVolume && (
-              <div className="mt-3 grid gap-2">
-                <Label className="inline-flex items-center cursor-pointer">
-                  <input
-                    type="checkbox"
-                    value=""
-                    checked={newVolume}
-                    className="sr-only peer"
-                    onChange={() => {
-                      setNewVolume(!newVolume);
+                    if (errors.volumeSize) {
+                      setErrors({
+                        ...errors,
+                        volumeSize: false,
+                      });
+                    }
+                  }}
+                >
+                </input>
+                <div className="relative w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-teal-600 dark:peer-checked:bg-teal-600"></div>
+                <span className="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">
+                  New Volume
+                </span>
+              </Label>
+              {newVolume ? (
+                <Input
+                  type="input"
+                  onFocus={(e) => (e.target.type = "text")}
+                  style={{ width: "100%", fontWeight: "normal" }}
+                  value={formData.volume}
+                  onChange={(e) => {
+                    setFormData({ ...formData, volume: e.target.value });
+                  }}
+                  placeholder="Enter new volume name"
+                />
+              ) : (
+                <Select
+                  value={formData.volume}
+                  onValueChange={(value) => {
+                    setFormData({ ...formData, volume: value });
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a volume" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {volumes.map((volume) => (
+                      <SelectItem key={volume.name} value={volume.name}>
+                        {volume.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+              {newVolume ? (
+                <div className="grid gap-1">
+                  <Label htmlFor="volumeSize">Volume size (Gi)</Label>
+                  <Input
+                    id="volumeSize"
+                    type="text"
+                    inputMode="decimal"
+                    placeholder="1"
+                    value={formData.volumeSize}
+                    className={
+                      errors.volumeSize
+                        ? "max-w-[180px] border-red-500 " +
+                          "focus:border-red-500"
+                        : "max-w-[180px]"
+                    }
+                    onChange={(e) => {
                       setFormData({
                         ...formData,
-                        volume: "",
-                        volumeSize: parseVolumeSize(),
+                        volumeSize: e.target.value,
                       });
-
-                      if (errors.volume || errors.volumeSize) {
-                        setErrors({
-                          ...errors,
-                          volume: false,
-                          volumeSize: false,
-                        });
+                      if (errors.volumeSize) {
+                        setErrors({ ...errors, volumeSize: false });
                       }
                     }}
                   />
-                  <div className="relative w-9 h-5 bg-gray-200 rounded-full peer peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 peer-checked:bg-teal-600 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full after:absolute after:start-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-['']"></div>
-                  <span className="ms-3 text-sm font-medium text-gray-900">
-                    New Volume
-                  </span>
-                </Label>
-                {newVolume ? (
-                  <>
-                    <Input
-                      type="input"
-                      onFocus={(e) => (e.target.type = "text")}
-                      style={{ width: "100%", fontWeight: "normal" }}
-                      value={formData.volume}
-                      className={
-                        errors.volume
-                          ? "border-red-500 focus:border-red-500"
-                          : ""
-                      }
-                      onChange={(e) => {
-                        setFormData({ ...formData, volume: e.target.value });
-                        if (errors.volume) {
-                          setErrors({ ...errors, volume: false });
-                        }
-                      }}
-                      placeholder="Enter new volume name"
-                    />
-                    <div className="grid gap-1">
-                      <Label htmlFor="volumeSize">Volume size (Gi)</Label>
-                      <Input
-                        id="volumeSize"
-                        type="text"
-                        inputMode="decimal"
-                        placeholder="1"
-                        value={formData.volumeSize}
-                        className={
-                          errors.volumeSize
-                            ? "max-w-[180px] border-red-500 " +
-                              "focus:border-red-500"
-                            : "max-w-[180px]"
-                        }
-                        onChange={(e) => {
-                          setFormData({
-                            ...formData,
-                            volumeSize: e.target.value,
-                          });
-                          if (errors.volumeSize) {
-                            setErrors({ ...errors, volumeSize: false });
-                          }
-                        }}
-                      />
-                    </div>
-                  </>
-                ) : (
-                  <Select
-                    value={formData.volume}
-                    onValueChange={(value) => {
-                      setFormData({ ...formData, volume: value });
-                      if (errors.volume) {
-                        setErrors({ ...errors, volume: false });
-                      }
-                    }}
-                  >
-                    <SelectTrigger
-                      className={
-                        errors.volume
-                          ? "border-red-500 focus:border-red-500"
-                          : ""
-                      }
-                    >
-                      <SelectValue placeholder="Select a volume" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {volumes.map((volume) => (
-                        <SelectItem key={volume.name} value={volume.name}>
-                          {volume.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              </div>
-            )}
+                </div>
+              ) : null}
+            </div>
           </div>
         </div>
         <DialogFooter>

--- a/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
+++ b/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
@@ -147,7 +147,7 @@ function TerminalFormPopover() {
           return;
         }
 
-        setVolumes(nextVolumes);
+        setVolumes(nextVolumes.managed_volume ?? []);
       } catch (error) {
         if (cancelled) {
           return;
@@ -541,7 +541,7 @@ function TerminalFormPopover() {
                 </Select>
               )}
               {newVolume ? (
-                <div className="grid gap-1">
+                <div className="grid gap-1 mt-2">
                   <Label htmlFor="volumeSize">Volume size (Gi)</Label>
                   <Input
                     id="volumeSize"

--- a/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
+++ b/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
@@ -1,4 +1,5 @@
 import createServiceApi from "@/api/services/createServiceApi";
+import getVolumesApi from "@/api/volumes/getVolumesApi";
 import RequestButton from "@/components/RequestButton";
 import { Button } from "@/components/ui/button";
 import {
@@ -21,6 +22,7 @@ import {
 import { useAuth } from "@/contexts/AuthContext";
 import useGetPrivateBuckets from "@/hooks/useGetPrivateBuckets";
 import { alert } from "@/lib/alert";
+import { errorMessage } from "@/lib/error";
 import {
   fetchFromGitHubOptions,
   generateReadableName,
@@ -29,7 +31,10 @@ import {
 } from "@/lib/utils";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
-import { Service } from "@/pages/ui/services/models/service";
+import {
+  ManagedVolume,
+  Service,
+} from "@/pages/ui/services/models/service";
 import OscarColors from "@/styles";
 import { Plus, RefreshCcwIcon } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -39,10 +44,44 @@ const TERMINAL_FDL_URL =
 const TERMINAL_SCRIPT_URL =
   "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/main/crates/ghostty-web/script.sh";
 
+function parseVolumeSize(size?: string): string {
+  if (!size) {
+    return "1";
+  }
+
+  const parsedSize = size.trim().match(/^(\d+(?:\.\d+)?)(Mi|Gi)$/);
+
+  if (!parsedSize) {
+    return "1";
+  }
+
+  const numericSize = Number(parsedSize[1]);
+  const unit = parsedSize[2];
+
+  if (unit === "Mi") {
+    return String(numericSize / 1024);
+  }
+
+  return parsedSize[1];
+}
+
+function isValidVolumeSize(value: string): boolean {
+  const trimmedValue = value.trim();
+
+  if (!/^\d+(\.\d+)?$/.test(trimmedValue)) {
+    return false;
+  }
+
+  return Number(trimmedValue) > 0;
+}
+
 function TerminalFormPopover() {
   const [isOpen, setIsOpen] = useState(false);
   const [mountBucket, setMountBucket] = useState(false);
   const [newBucket, setNewBucket] = useState(false);
+  const [mountVolume, setMountVolume] = useState(false);
+  const [newVolume, setNewVolume] = useState(false);
+  const [volumes, setVolumes] = useState<ManagedVolume[]>([]);
   const { systemConfig, authData } = useAuth();
   const { refreshServices } = useServicesContext();
   const buckets = useGetPrivateBuckets();
@@ -50,7 +89,10 @@ function TerminalFormPopover() {
   const oidcGroups = getAllowedVOs(systemConfig, authData);
 
   function nameService() {
-    return `terminal-${generateReadableName(6)}-${genRandomString(8).toLowerCase()}`;
+    return (
+      `terminal-${generateReadableName(6)}-` +
+      `${genRandomString(8).toLowerCase()}`
+    );
   }
 
   const [formData, setFormData] = useState({
@@ -59,6 +101,8 @@ function TerminalFormPopover() {
     memoryRam: "256",
     memoryUnit: "Mi",
     bucket: "",
+    volume: "",
+    volumeSize: "1",
     refreshToken: "",
     vo: "",
     token: "",
@@ -69,6 +113,8 @@ function TerminalFormPopover() {
     cpuCores: false,
     memoryRam: false,
     bucket: false,
+    volume: false,
+    volumeSize: false,
     vo: false,
   });
 
@@ -79,7 +125,9 @@ function TerminalFormPopover() {
   }, [formData.vo, oidcGroups]);
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      return;
+    }
 
     setFormData((prev) => ({
       ...prev,
@@ -88,19 +136,78 @@ function TerminalFormPopover() {
       memoryRam: "256",
       memoryUnit: "Mi",
       bucket: "",
+      volume: "",
+      volumeSize: "1",
       refreshToken: "",
       token: genRandomString(128),
     }));
     setMountBucket(false);
     setNewBucket(false);
+    setMountVolume(false);
+    setNewVolume(false);
+    setVolumes([]);
     setErrors({
       name: false,
       cpuCores: false,
       memoryRam: false,
       bucket: false,
+      volume: false,
+      volumeSize: false,
       vo: false,
     });
   }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadVolumes = async () => {
+      try {
+        const nextVolumes = await getVolumesApi();
+
+        if (cancelled) {
+          return;
+        }
+
+        setVolumes(nextVolumes);
+
+        if (!mountVolume) {
+          return;
+        }
+
+        setNewVolume(nextVolumes.length === 0);
+        setFormData((prev) => ({
+          ...prev,
+          volume:
+            nextVolumes.length === 0
+              ? prev.volume
+              : nextVolumes.some((volume) => volume.name === prev.volume)
+                ? prev.volume
+                : "",
+        }));
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+
+        console.error(error);
+        setVolumes([]);
+
+        if (mountVolume) {
+          setNewVolume(true);
+        }
+      }
+    };
+
+    void loadVolumes();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, mountVolume]);
 
   const handleDeploy = async () => {
     const newErrors = {
@@ -108,6 +215,9 @@ function TerminalFormPopover() {
       cpuCores: !formData.cpuCores,
       memoryRam: !formData.memoryRam,
       bucket: mountBucket && !formData.bucket,
+      volume: mountVolume && !formData.volume,
+      volumeSize:
+        mountVolume && newVolume && !isValidVolumeSize(formData.volumeSize),
       vo: !formData.vo,
     };
 
@@ -129,18 +239,32 @@ function TerminalFormPopover() {
       const scriptText = await scriptResponse.text();
 
       const services = yamlToServices(fdlText, scriptText);
-      if (!services?.length) throw Error("No services found");
+
+      if (!services?.length) {
+        throw new Error("No services found");
+      }
 
       const service = services[0];
       const serviceName = formData.name || nameService();
-      const workspaceDir = mountBucket
-        ? `/mnt/${formData.bucket}`
-        : `/tmp/${serviceName}`;
+      const workspaceDir = mountVolume
+        ? `/mnt/volumes/${formData.volume}`
+        : mountBucket
+          ? `/mnt/buckets/${formData.bucket}`
+          : `/tmp/${serviceName}`;
       const baseSecrets = Object.fromEntries(
         Object.entries(service.environment.secrets || {}).filter(
           ([key]) => key !== "OSCAR_OIDC_REFRESH_TOKEN"
         )
       );
+      const volumeConfig = mountVolume
+        ? {
+            name: formData.volume,
+            mount_path: `/mnt/volumes/${formData.volume}`,
+            ...(newVolume
+              ? { size: `${formData.volumeSize.trim()}Gi` }
+              : {}),
+          }
+        : undefined;
 
       const modifiedService: Service = {
         ...service,
@@ -152,10 +276,12 @@ function TerminalFormPopover() {
         mount: mountBucket
           ? {
               ...service.mount,
-              path: formData.bucket,
-              storage_provider: service.mount?.storage_provider ?? "minio.default",
+              path: `buckets/${formData.bucket}`,
+              storage_provider:
+                service.mount?.storage_provider ?? "minio.default",
             }
           : undefined,
+        volume: volumeConfig,
         environment: {
           variables: {
             ...service.environment.variables,
@@ -183,7 +309,9 @@ function TerminalFormPopover() {
       setIsOpen(false);
     } catch (error) {
       console.error(error);
-      alert.error("Error deploying terminal instance");
+      alert.error(
+        `Error deploying terminal instance: ${errorMessage(error)}`
+      );
     }
   };
 
@@ -201,7 +329,7 @@ function TerminalFormPopover() {
           New
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-w-[600px] max-h-[90%] gap-4 flex flex-col">
+      <DialogContent className="max-h-[90%] max-w-[600px] gap-4 flex flex-col">
         <DialogHeader>
           <DialogTitle>
             <span style={{ color: OscarColors.DarkGrayText }}>
@@ -234,10 +362,14 @@ function TerminalFormPopover() {
               id="name"
               placeholder="Enter service name"
               value={formData.name}
-              className={errors.name ? "border-red-500 focus:border-red-500" : ""}
+              className={
+                errors.name ? "border-red-500 focus:border-red-500" : ""
+              }
               onChange={(e) => {
                 setFormData({ ...formData, name: e.target.value });
-                if (errors.name) setErrors({ ...errors, name: false });
+                if (errors.name) {
+                  setErrors({ ...errors, name: false });
+                }
               }}
             ></Input>
           </div>
@@ -250,10 +382,14 @@ function TerminalFormPopover() {
                 step={0.1}
                 placeholder="Enter CPU Cores"
                 value={formData.cpuCores}
-                className={errors.cpuCores ? "border-red-500 focus:border-red-500" : ""}
+                className={
+                  errors.cpuCores ? "border-red-500 focus:border-red-500" : ""
+                }
                 onChange={(e) => {
                   setFormData({ ...formData, cpuCores: e.target.value });
-                  if (errors.cpuCores) setErrors({ ...errors, cpuCores: false });
+                  if (errors.cpuCores) {
+                    setErrors({ ...errors, cpuCores: false });
+                  }
                 }}
               ></Input>
             </div>
@@ -266,10 +402,16 @@ function TerminalFormPopover() {
                   step={formData.memoryUnit === "Gi" ? 1 : 256}
                   placeholder="Enter RAM"
                   value={formData.memoryRam}
-                  className={errors.memoryRam ? "border-red-500 focus:border-red-500" : ""}
+                  className={
+                    errors.memoryRam
+                      ? "border-red-500 focus:border-red-500"
+                      : ""
+                  }
                   onChange={(e) => {
                     setFormData({ ...formData, memoryRam: e.target.value });
-                    if (errors.memoryRam) setErrors({ ...errors, memoryRam: false });
+                    if (errors.memoryRam) {
+                      setErrors({ ...errors, memoryRam: false });
+                    }
                   }}
                 />
               </div>
@@ -295,7 +437,9 @@ function TerminalFormPopover() {
               value={formData.vo}
               onValueChange={(value) => {
                 setFormData({ ...formData, vo: value });
-                if (errors.vo) setErrors({ ...errors, vo: false });
+                if (errors.vo) {
+                  setErrors({ ...errors, vo: false });
+                }
               }}
             >
               <SelectTrigger
@@ -335,13 +479,21 @@ function TerminalFormPopover() {
                 checked={mountBucket}
                 className="sr-only peer"
                 onChange={() => {
-                  setMountBucket(!mountBucket);
+                  const nextMountBucket = !mountBucket;
+
+                  setMountBucket(nextMountBucket);
                   setNewBucket(false);
-                  setFormData({ ...formData, bucket: "" });
-                  if (errors.bucket) setErrors({ ...errors, bucket: false });
+                  setFormData({
+                    ...formData,
+                    bucket: "",
+                  });
+
+                  if (errors.bucket) {
+                    setErrors({ ...errors, bucket: false });
+                  }
                 }}
               />
-              <div className="relative w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-teal-600"></div>
+              <div className="relative w-9 h-5 bg-gray-200 rounded-full peer peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 peer-checked:bg-teal-600 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full after:absolute after:start-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-['']"></div>
               <span className="ms-3 text-sm font-medium text-gray-900">
                 Mount bucket
               </span>
@@ -357,10 +509,13 @@ function TerminalFormPopover() {
                     onChange={() => {
                       setNewBucket(!newBucket);
                       setFormData({ ...formData, bucket: "" });
-                      if (errors.bucket) setErrors({ ...errors, bucket: false });
+
+                      if (errors.bucket) {
+                        setErrors({ ...errors, bucket: false });
+                      }
                     }}
                   />
-                  <div className="relative w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-teal-600"></div>
+                  <div className="relative w-9 h-5 bg-gray-200 rounded-full peer peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 peer-checked:bg-teal-600 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full after:absolute after:start-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-['']"></div>
                   <span className="ms-3 text-sm font-medium text-gray-900">
                     New Bucket
                   </span>
@@ -371,10 +526,16 @@ function TerminalFormPopover() {
                       type="input"
                       onFocus={(e) => (e.target.type = "text")}
                       style={{ width: "100%", fontWeight: "normal" }}
-                      className={errors.bucket ? "border-red-500 focus:border-red-500" : ""}
+                      className={
+                        errors.bucket
+                          ? "border-red-500 focus:border-red-500"
+                          : ""
+                      }
                       onChange={(e) => {
                         setFormData({ ...formData, bucket: e.target.value });
-                        if (errors.bucket) setErrors({ ...errors, bucket: false });
+                        if (errors.bucket) {
+                          setErrors({ ...errors, bucket: false });
+                        }
                       }}
                       placeholder="Enter new bucket name"
                     />
@@ -383,17 +544,26 @@ function TerminalFormPopover() {
                       value={formData.bucket}
                       onValueChange={(value) => {
                         setFormData({ ...formData, bucket: value });
-                        if (errors.bucket) setErrors({ ...errors, bucket: false });
+                        if (errors.bucket) {
+                          setErrors({ ...errors, bucket: false });
+                        }
                       }}
                     >
                       <SelectTrigger
-                        className={errors.bucket ? "border-red-500 focus:border-red-500" : ""}
+                        className={
+                          errors.bucket
+                            ? "border-red-500 focus:border-red-500"
+                            : ""
+                        }
                       >
                         <SelectValue placeholder="Select a bucket" />
                       </SelectTrigger>
                       <SelectContent>
                         {buckets.map((bucket) => (
-                          <SelectItem key={bucket.bucket_name} value={bucket.bucket_name}>
+                          <SelectItem
+                            key={bucket.bucket_name}
+                            value={bucket.bucket_name}
+                          >
                             {bucket.bucket_name}
                           </SelectItem>
                         ))}
@@ -401,6 +571,148 @@ function TerminalFormPopover() {
                     </Select>
                   )}
                 </div>
+              </div>
+            )}
+          </div>
+          <div>
+            <Label>Volume</Label>
+            <hr className="mb-2" />
+            <Label className="inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                value=""
+                checked={mountVolume}
+                className="sr-only peer"
+                onChange={() => {
+                  const nextMountVolume = !mountVolume;
+                  const defaultNewVolume = nextMountVolume && volumes.length === 0;
+
+                  setMountVolume(nextMountVolume);
+                  setNewVolume(defaultNewVolume);
+                  setFormData({
+                    ...formData,
+                    volume: "",
+                    volumeSize: parseVolumeSize(),
+                  });
+
+                  if (errors.volume || errors.volumeSize) {
+                    setErrors({
+                      ...errors,
+                      volume: false,
+                      volumeSize: false,
+                    });
+                  }
+                }}
+              />
+              <div className="relative w-9 h-5 bg-gray-200 rounded-full peer peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 peer-checked:bg-teal-600 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full after:absolute after:start-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-['']"></div>
+              <span className="ms-3 text-sm font-medium text-gray-900">
+                Mount volume
+              </span>
+            </Label>
+            {mountVolume && (
+              <div className="mt-3 grid gap-2">
+                <Label className="inline-flex items-center cursor-pointer">
+                  <input
+                    type="checkbox"
+                    value=""
+                    checked={newVolume}
+                    className="sr-only peer"
+                    onChange={() => {
+                      setNewVolume(!newVolume);
+                      setFormData({
+                        ...formData,
+                        volume: "",
+                        volumeSize: parseVolumeSize(),
+                      });
+
+                      if (errors.volume || errors.volumeSize) {
+                        setErrors({
+                          ...errors,
+                          volume: false,
+                          volumeSize: false,
+                        });
+                      }
+                    }}
+                  />
+                  <div className="relative w-9 h-5 bg-gray-200 rounded-full peer peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 peer-checked:bg-teal-600 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full after:absolute after:start-[2px] after:top-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-['']"></div>
+                  <span className="ms-3 text-sm font-medium text-gray-900">
+                    New Volume
+                  </span>
+                </Label>
+                {newVolume ? (
+                  <>
+                    <Input
+                      type="input"
+                      onFocus={(e) => (e.target.type = "text")}
+                      style={{ width: "100%", fontWeight: "normal" }}
+                      value={formData.volume}
+                      className={
+                        errors.volume
+                          ? "border-red-500 focus:border-red-500"
+                          : ""
+                      }
+                      onChange={(e) => {
+                        setFormData({ ...formData, volume: e.target.value });
+                        if (errors.volume) {
+                          setErrors({ ...errors, volume: false });
+                        }
+                      }}
+                      placeholder="Enter new volume name"
+                    />
+                    <div className="grid gap-1">
+                      <Label htmlFor="volumeSize">Volume size (Gi)</Label>
+                      <Input
+                        id="volumeSize"
+                        type="text"
+                        inputMode="decimal"
+                        placeholder="1"
+                        value={formData.volumeSize}
+                        className={
+                          errors.volumeSize
+                            ? "max-w-[180px] border-red-500 " +
+                              "focus:border-red-500"
+                            : "max-w-[180px]"
+                        }
+                        onChange={(e) => {
+                          setFormData({
+                            ...formData,
+                            volumeSize: e.target.value,
+                          });
+                          if (errors.volumeSize) {
+                            setErrors({ ...errors, volumeSize: false });
+                          }
+                        }}
+                      />
+                    </div>
+                  </>
+                ) : (
+                  <Select
+                    value={formData.volume}
+                    onValueChange={(value) => {
+                      setFormData({ ...formData, volume: value });
+                      if (errors.volume) {
+                        setErrors({ ...errors, volume: false });
+                      }
+                    }}
+                  >
+                    <SelectTrigger
+                      className={
+                        errors.volume
+                          ? "border-red-500 focus:border-red-500"
+                          : ""
+                      }
+                    >
+                      <SelectValue placeholder="Select a volume" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {volumes.map((volume) => (
+                        <SelectItem key={volume.name} value={volume.name}>
+                          {volume.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
               </div>
             )}
           </div>

--- a/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
+++ b/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
@@ -249,7 +249,7 @@ function TerminalFormPopover() {
       const workspaceDir = mountVolume
         ? `/mnt/volumes/${formData.volume}`
         : mountBucket
-          ? `/mnt/buckets/${formData.bucket}`
+          ? `/mnt/${formData.bucket}`
           : `/tmp/${serviceName}`;
       const baseSecrets = Object.fromEntries(
         Object.entries(service.environment.secrets || {}).filter(
@@ -276,7 +276,7 @@ function TerminalFormPopover() {
         mount: mountBucket
           ? {
               ...service.mount,
-              path: `buckets/${formData.bucket}`,
+              path: formData.bucket,
               storage_provider:
                 service.mount?.storage_provider ?? "minio.default",
             }

--- a/src/pages/ui/volumes/components/AddVolumeButton/index.tsx
+++ b/src/pages/ui/volumes/components/AddVolumeButton/index.tsx
@@ -1,0 +1,147 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { useVolumes } from "@/contexts/Volumes/VolumesContext";
+import { ManagedVolumeCreateRequest } from "@/pages/ui/services/models/service";
+import { Plus } from "lucide-react";
+import { useEffect, useState } from "react";
+
+const DEFAULT_VOLUME_SIZE = "1";
+
+const emptyVolume: ManagedVolumeCreateRequest = {
+  name: "",
+  size: "1Gi",
+};
+
+function isValidVolumeSize(value: string): boolean {
+  const trimmedValue = value.trim();
+
+  if (!/^\d+(\.\d+)?$/.test(trimmedValue)) {
+    return false;
+  }
+
+  return Number(trimmedValue) > 0;
+}
+
+export default function AddVolumeButton() {
+  const [formVolume, setFormVolume] =
+    useState<ManagedVolumeCreateRequest>(emptyVolume);
+  const [volumeSizeInput, setVolumeSizeInput] = useState(DEFAULT_VOLUME_SIZE);
+  const [isOpen, setIsOpen] = useState(false);
+  const { createVolume } = useVolumes();
+  const volumeNameIsValid = formVolume.name.trim().length > 0;
+  const volumeSizeIsValid = isValidVolumeSize(volumeSizeInput);
+  const formIsValid = volumeNameIsValid && volumeSizeIsValid;
+
+  const handleCreateVolume = async () => {
+    if (!formIsValid) {
+      return;
+    }
+
+    await createVolume(formVolume);
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      setFormVolume(emptyVolume);
+      setVolumeSizeInput(DEFAULT_VOLUME_SIZE);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setIsOpen(false);
+      }
+
+      if (e.key === "Enter") {
+        void handleCreateVolume();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [formIsValid, isOpen, formVolume]);
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="mainGreen" style={{ gap: 8 }}>
+          <Plus size={20} />
+          New
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80">
+        <div className="grid gap-4">
+          <div className="space-y-2">
+            <h4 className="font-medium leading-none">New Volume</h4>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="volumeName">Volume Name:</Label>
+            <Input
+              id="volumeName"
+              value={formVolume.name}
+              onChange={(e) => {
+                setFormVolume((prev) => ({
+                  ...prev,
+                  name: e.target.value,
+                }));
+              }}
+              placeholder="Enter volume name"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="volumeSize">Size (Gi):</Label>
+            <div className="grid gap-1">
+              <Input
+                id="volumeSize"
+                type="number"
+                min="0.1"
+                step="any"
+                inputMode="decimal"
+                value={volumeSizeInput}
+                onChange={(e) => {
+                  const nextValue = e.target.value;
+
+                  setVolumeSizeInput(nextValue);
+                  setFormVolume((prev) => ({
+                    ...prev,
+                    size: `${nextValue.trim()}Gi`,
+                  }));
+                }}
+                placeholder="1"
+              />
+              {!volumeSizeIsValid && (
+                <span className="text-xs text-red-500">
+                  Enter a positive integer or decimal value.
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="flex justify-end space-x-2">
+            <Button variant="outline" onClick={() => setIsOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void handleCreateVolume()}
+              disabled={!formIsValid}
+            >
+              Create
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/pages/ui/volumes/components/Topbar.tsx
+++ b/src/pages/ui/volumes/components/Topbar.tsx
@@ -1,0 +1,101 @@
+import GenericTopbar from "@/components/Topbar";
+import Divider from "@/components/ui/divider";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
+import {
+  VolumeFilterBy,
+  useVolumes,
+} from "@/contexts/Volumes/VolumesContext";
+import { Filter, Search } from "lucide-react";
+import { SelectIcon } from "@radix-ui/react-select";
+import AddVolumeButton from "./AddVolumeButton";
+
+function VolumesTopbar() {
+  const { updateVolumes, volumesFilter, setVolumesFilter } = useVolumes();
+
+  return (
+    <GenericTopbar
+      defaultHeader={{ title: "Volumes", linkTo: "/ui/volumes" }}
+      refresher={updateVolumes}
+      secondaryRow={
+        <div className="grid grid-cols-[auto_1fr] w-full p-2 pt-1 gap-2">
+          <Select
+            value={volumesFilter.by}
+            onValueChange={(value: VolumeFilterBy) => {
+              setVolumesFilter({
+                ...volumesFilter,
+                by: value,
+              });
+            }}
+          >
+            <SelectTrigger className="w-max">
+              <SelectIcon>
+                <Filter size={16} className="mr-2" />
+              </SelectIcon>
+            </SelectTrigger>
+
+            <SelectContent>
+              {Object.values(VolumeFilterBy).map((value) => {
+                return (
+                  <SelectItem key={value} value={value}>
+                    {"By " + value.toLocaleLowerCase()}
+                  </SelectItem>
+                );
+              })}
+              <Divider />
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "6px",
+                }}
+              >
+                <Checkbox
+                  id="ownedVolumes"
+                  checked={volumesFilter.myVolumes}
+                  onCheckedChange={(checked) => {
+                    setVolumesFilter({
+                      ...volumesFilter,
+                      myVolumes: checked as boolean,
+                    });
+                  }}
+                  style={{ fontSize: 16 }}
+                />
+                <label
+                  htmlFor="ownedVolumes"
+                  style={{ fontSize: 14, marginTop: "1px" }}
+                >
+                  My volumes
+                </label>
+              </div>
+            </SelectContent>
+          </Select>
+          <Input
+            placeholder={`Search volumes by ${volumesFilter.by}`}
+            value={volumesFilter.query}
+            onChange={(e) =>
+              setVolumesFilter({
+                ...volumesFilter,
+                query: e.target.value,
+              })
+            }
+            endIcon={<Search size={16} />}
+          />
+        </div>
+      }
+    >
+      <div className="flex flex-row items-center w-full justify-end gap-2">
+        <AddVolumeButton />
+      </div>
+    </GenericTopbar>
+  );
+}
+
+export default VolumesTopbar;

--- a/src/pages/ui/volumes/components/VolumeList/index.tsx
+++ b/src/pages/ui/volumes/components/VolumeList/index.tsx
@@ -1,6 +1,7 @@
 import DeleteDialog from "@/components/DeleteDialog";
 import ResponsiveOwnerField from "@/components/ResponsiveOwnerField";
 import GenericTable from "@/components/Table";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAuth } from "@/contexts/AuthContext";
@@ -8,7 +9,7 @@ import { useVolumes } from "@/contexts/Volumes/VolumesContext";
 import { isUserOscar } from "@/lib/utils";
 import { ManagedVolume } from "@/pages/ui/services/models/service";
 import OscarColors from "@/styles";
-import { ExternalLinkIcon, LoaderPinwheel, Trash } from "lucide-react";
+import { AlertCircle, ExternalLinkIcon, LoaderPinwheel, Trash } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
@@ -47,6 +48,7 @@ export default function VolumeList() {
     volumesAreLoading,
     deleteVolume,
     volumesFilter,
+    volumesLoadingError,
   } = useVolumes();
   const [itemsToDelete, setItemsToDelete] = useState<ManagedVolume[]>([]);
   const [filteredVolumes, setFilteredVolumes] =
@@ -80,6 +82,22 @@ export default function VolumeList() {
     setFilteredVolumes(nextVolumes);
   }, [authData, volumes, volumesFilter]);
 
+  function loadingErrorView() {
+    return (
+      <div className="flex items-center justify-center h-full w-full">
+        <Alert variant="destructive" className="max-w-md bg-red-50 text-red-400">
+          <div className="flex flex-col items-center text-center">
+          <AlertCircle className="h-6 w-6 mb-2" />
+          <AlertTitle>Failed to load volumes</AlertTitle>
+          <AlertDescription className="mt-1 text-sm">
+            Could not retrieve volumes data due to an unexpected error. Contact your administrator or try again later.
+          </AlertDescription>
+          </div>
+        </Alert>
+      </div>
+    );
+  }
+
   return (
     <>
       <DeleteDialog
@@ -100,6 +118,9 @@ export default function VolumeList() {
             color={OscarColors.Green3}
           />
         </div>
+      )
+      : volumesLoadingError ? (
+        loadingErrorView()
       ) : (
         <GenericTable<ManagedVolume>
           idKey="name"

--- a/src/pages/ui/volumes/components/VolumeList/index.tsx
+++ b/src/pages/ui/volumes/components/VolumeList/index.tsx
@@ -169,7 +169,19 @@ export default function VolumeList() {
                       ))}
                     </div>
                   ) : (
+                    row.created_by_service ? (
+                      <Link
+                        to={`/ui/services/${row.created_by_service}/settings`}
+                        className="grid grid-cols-[auto_1fr] no-underline hover:underline underline-offset-2 border-gray-400"
+                      >
+                        <span className="truncate min-w-[70px]">
+                          {row.created_by_service}
+                        </span>
+                        <ExternalLinkIcon size={12} className="self-center ml-[2px]" />
+                      </Link>
+                    ) : (
                     <span></span>
+                    )
                   )}
                 </>
               ),

--- a/src/pages/ui/volumes/components/VolumeList/index.tsx
+++ b/src/pages/ui/volumes/components/VolumeList/index.tsx
@@ -1,0 +1,214 @@
+import DeleteDialog from "@/components/DeleteDialog";
+import ResponsiveOwnerField from "@/components/ResponsiveOwnerField";
+import GenericTable from "@/components/Table";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipTrigger } from "@/components/ui/tooltip";
+import { useAuth } from "@/contexts/AuthContext";
+import { useVolumes } from "@/contexts/Volumes/VolumesContext";
+import { isUserOscar } from "@/lib/utils";
+import { ManagedVolume } from "@/pages/ui/services/models/service";
+import OscarColors from "@/styles";
+import { ExternalLinkIcon, LoaderPinwheel, Trash } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+const statusColors: Record<string, string> = {
+  ready: "bg-green-100 text-green-700 border-green-300",
+  in_use: "bg-blue-100 text-blue-700 border-blue-300",
+  pending: "bg-yellow-100 text-yellow-700 border-yellow-300",
+  error: "bg-red-100 text-red-700 border-red-300",
+  deleting: "bg-orange-100 text-orange-700 border-orange-300",
+  deleted: "bg-gray-100 text-gray-700 border-gray-300",
+};
+
+const creationModeColors: Record<string, string> = {
+  api: "bg-teal-100 text-teal-700 border-teal-300",
+  service: "bg-purple-100 text-purple-700 border-purple-300",
+};
+
+function formatBadge(value: string, colors: Record<string, string>) {
+  const normalized = value?.toLowerCase() || "unknown";
+  const badgeColors =
+    colors[normalized] || "bg-gray-100 text-gray-700 border-gray-300";
+
+  return (
+    <span
+      className={`font-bold px-2 py-1 rounded-full text-xs border ${badgeColors}`}
+    >
+      {normalized.toUpperCase()}
+    </span>
+  );
+}
+
+export default function VolumeList() {
+  const { authData } = useAuth();
+  const {
+    volumes,
+    volumesAreLoading,
+    deleteVolume,
+    volumesFilter,
+  } = useVolumes();
+  const [itemsToDelete, setItemsToDelete] = useState<ManagedVolume[]>([]);
+  const [filteredVolumes, setFilteredVolumes] =
+    useState<ManagedVolume[]>(volumes);
+
+  useEffect(() => {
+    let nextVolumes = volumes;
+
+    if (volumesFilter.myVolumes) {
+      nextVolumes = nextVolumes.filter((volume) => {
+        const owner = volume.owner_user || "";
+        return (
+          owner === authData.egiSession?.sub || isUserOscar(authData, { owner })
+        );
+      });
+    }
+
+    if (volumesFilter.query) {
+      nextVolumes = nextVolumes.filter((volume) => {
+        const fieldToFilter =
+          volumesFilter.by === "name"
+            ? volume.name
+            : volumesFilter.by === "owner"
+            ? volume.owner_user || ""
+            : volume.created_by_service || "";
+        const query = volumesFilter.query.toLowerCase();
+        return fieldToFilter.toLowerCase().includes(query);
+      });
+    }
+
+    setFilteredVolumes(nextVolumes);
+  }, [authData, volumes, volumesFilter]);
+
+  return (
+    <>
+      <DeleteDialog
+        isOpen={itemsToDelete.length > 0}
+        onClose={() => setItemsToDelete([])}
+        onDelete={() => {
+          itemsToDelete.forEach((volume) => {
+            void deleteVolume(volume.name);
+          });
+        }}
+        itemNames={itemsToDelete.map((volume) => volume.name)}
+      />
+      {volumesAreLoading ? (
+        <div className="flex items-center justify-center h-screen">
+          <LoaderPinwheel
+            className="animate-spin"
+            size={60}
+            color={OscarColors.Green3}
+          />
+        </div>
+      ) : (
+        <GenericTable<ManagedVolume>
+          idKey="name"
+          data={filteredVolumes}
+          columns={[
+            {
+              header: "Name",
+              accessor: "name",
+              sortBy: "name",
+            },
+            {
+              header: "Owner",
+              accessor: (row) => (
+                <ResponsiveOwnerField
+                  owner={row.owner_user || "oscar"}
+                  sub={row.owner_user || "oscar"}
+                />
+              ),
+              sortBy: "owner_user",
+            },
+            {
+              header: "Size",
+              accessor: (row) => row.size || "-",
+              sortBy: "size",
+            },
+            {
+              header: "Service",
+              accessor: (row) => (
+                <>
+                  {row.attachments?.length ? (
+                    <div className="flex flex-col gap-1">
+                      {row.attachments.map((attachment) => (
+                        <Link
+                          key={attachment.service_name}
+                          to={`/ui/services/${attachment.service_name}/settings`}
+                          className="grid grid-cols-[auto_1fr] no-underline hover:underline underline-offset-2 border-gray-400"
+                        >
+                          <span className="truncate min-w-[70px]">
+                            {attachment.service_name}
+                          </span>
+                          <ExternalLinkIcon
+                            size={12}
+                            className="self-center ml-[2px]"
+                          />
+                        </Link>
+                      ))}
+                    </div>
+                  ) : (
+                    <span></span>
+                  )}
+                </>
+              ),
+              sortBy: "name",
+            },
+            {
+              header: "Status",
+              accessor: (row) =>
+                formatBadge(row.status?.phase || "unknown", statusColors),
+              sortBy: "name",
+            },
+            {
+              header: "Mode",
+              accessor: (row) =>
+                formatBadge(
+                  row.creation_mode || "unknown",
+                  creationModeColors
+                ),
+              sortBy: "creation_mode",
+            },
+          ]}
+          actions={[
+            {
+              button: (volume) => {
+                return (
+                  <Button
+                    variant="link"
+                    size="icon"
+                    onClick={() => {
+                      setItemsToDelete([...itemsToDelete, volume]);
+                    }}
+                  >
+                    <Trash color={OscarColors.Red} />
+                  </Button>
+                );
+              },
+            },
+          ]}
+          bulkActions={[
+            {
+              button: (items) => {
+                return (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        className="mt-[2px] ml-[4px]"
+                        onClick={() => setItemsToDelete(items)}
+                        variant={"destructive"}
+                      >
+                        <Trash className="w-4 h-4 mr-2" />
+                        Delete Volumes
+                      </Button>
+                    </TooltipTrigger>
+                  </Tooltip>
+                );
+              },
+            },
+          ]}
+        />
+      )}
+    </>
+  );
+}

--- a/src/pages/ui/volumes/router.tsx
+++ b/src/pages/ui/volumes/router.tsx
@@ -1,0 +1,30 @@
+import { Outlet, Route, Routes } from "react-router-dom";
+import VolumesTopbar from "./components/Topbar";
+import VolumeList from "./components/VolumeList";
+
+function VolumesRouter() {
+  return (
+    <Routes>
+      <Route
+        path="/"
+        element={
+          <div
+            style={{
+              flexGrow: 1,
+              flexBasis: 0,
+              display: "flex",
+              flexDirection: "column",
+            }}
+          >
+            <VolumesTopbar />
+            <Outlet />
+          </div>
+        }
+      >
+        <Route path="" element={<VolumeList />} />
+      </Route>
+    </Routes>
+  );
+}
+
+export default VolumesRouter;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -7,6 +7,8 @@ import { PrivacyPolicy } from "@/pages/PrivacyPolicy";
 import TermsOfUse from "@/pages/TermsOfUse";
 import { MinioProvider } from "@/contexts/Minio/MinioContext";
 import MinioRouter from "@/pages/ui/minio/router";
+import { VolumesProvider } from "@/contexts/Volumes/VolumesContext";
+import VolumesRouter from "@/pages/ui/volumes/router";
 import InfoView from "@/pages/ui/info";
 import { ServicesProvider } from "@/pages/ui/services/context/ServicesContext";
 import JunoView from "@/pages/ui/juno";
@@ -29,7 +31,9 @@ function AppRouter() {
             <ProtectedRoute>
               <ServicesProvider>
                 <MinioProvider>
-                  <AppLayout />
+                  <VolumesProvider>
+                    <AppLayout />
+                  </VolumesProvider>
                 </MinioProvider>
               </ServicesProvider>
             </ProtectedRoute>
@@ -37,6 +41,7 @@ function AppRouter() {
         >
           <Route path="services/*" element={<ServicesRouter />} />
           <Route path="minio/*" element={<MinioRouter />} />
+          <Route path="volumes/*" element={<VolumesRouter />} />
           <Route path="info" element={<InfoView />} />
           <Route path="notebooks" element={<JunoView />} />
           <Route path="flows" element={<FlowsView />} />


### PR DESCRIPTION
## Summary
Add managed volume support to `oscar-dashboard-devel`.

This PR introduces top-level volume management, lets Hub deployments select an existing volume or create a new one, adds Hub source selection, and updates the volumes table to show attached services returned by the OSCAR API.

## Changes
- add a top-level `Volumes` section with list, create, and delete actions
- add `/system/volumes` API clients and volume types
- extend Hub deploy popover to reuse or create managed volumes
- show volume size as numeric `Gi` input in Volumes and Hub forms
- add `Manage Sources` to Hub and load crates from the selected repo/branch
- show attached services in the Volumes table using `attachments`

## Validation
- `npm run build`
- `npx eslint src/pages/ui/hub/index.tsx src/pages/ui/hub/components/HubSrcPopoverButton/index.tsx`
- `npx eslint src/pages/ui/hub/components/HubServiceConfPopover/index.tsx`
- `npx eslint src/pages/ui/volumes/components/AddVolumeButton/index.tsx`
- `npx eslint src/pages/ui/services/models/service.ts src/pages/ui/volumes/components/VolumeList/index.tsx`