### PR TITLE
feat: add deployment visibility to services dashboard

### DIFF
--- a/src/api/deployment/getDeploymentLogsApi.ts
+++ b/src/api/deployment/getDeploymentLogsApi.ts
@@ -1,0 +1,26 @@
+import axios from "axios";
+import { DeploymentLogStream } from "@/pages/ui/services/models/deployment";
+
+interface DeploymentLogsOptions {
+  timestamps?: boolean;
+  tailLines?: number;
+}
+
+async function getDeploymentLogsApi(
+  serviceName: string,
+  options: DeploymentLogsOptions = {}
+) {
+  const response = await axios.get(
+    `/system/services/${serviceName}/deployment/logs`,
+    {
+      params: {
+        timestamps: options.timestamps ?? false,
+        tailLines: options.tailLines ?? 200,
+      },
+    }
+  );
+
+  return response.data as DeploymentLogStream;
+}
+
+export default getDeploymentLogsApi;

--- a/src/api/deployment/getDeploymentStatusApi.ts
+++ b/src/api/deployment/getDeploymentStatusApi.ts
@@ -1,0 +1,10 @@
+import axios from "axios";
+import { DeploymentStatus } from "@/pages/ui/services/models/deployment";
+
+async function getDeploymentStatusApi(serviceName: string) {
+  const response = await axios.get(`/system/services/${serviceName}/deployment`);
+
+  return response.data as DeploymentStatus;
+}
+
+export default getDeploymentStatusApi;

--- a/src/api/services/getServicesApi.ts
+++ b/src/api/services/getServicesApi.ts
@@ -1,8 +1,14 @@
 import { Service } from "@/pages/ui/services/models/service";
 import axios from "axios";
 
-async function getServicesApi() {
-  const response = await axios.get("/system/services");
+interface GetServicesApiOptions {
+  includeDeployment?: boolean;
+}
+
+async function getServicesApi(options: GetServicesApiOptions = {}) {
+  const response = await axios.get("/system/services", {
+    params: options.includeDeployment ? { include: "deployment" } : undefined,
+  });
 
   return response.data as Service[];
 }

--- a/src/api/services/getServicesApi.ts
+++ b/src/api/services/getServicesApi.ts
@@ -5,7 +5,7 @@ interface GetServicesApiOptions {
   includeDeployment?: boolean;
 }
 
-async function getServicesApi(options: GetServicesApiOptions = {}) {
+async function getServicesApi(options: GetServicesApiOptions = {}): Promise<Service[]> {
   const response = await axios.get("/system/services", {
     params: options.includeDeployment ? { include: "deployment" } : undefined,
   });

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -15,7 +15,8 @@ import { AnimatePresence, motion } from "framer-motion";
 export type ColumnDef<T> = {
   header: string;
   accessor: keyof T | ((item: T) => React.ReactNode);
-  sortBy: keyof T ;
+  sortBy: string;
+  sortValue?: keyof T | ((item: T) => string | number | boolean | null | undefined);
 };
 
 type ActionButton<T> = {
@@ -50,15 +51,37 @@ function GenericTable<T extends object>({
   }, [data.length]);
 
   const [sortConfig, setSortConfig] = useState<{
-    key: keyof T;
+    key: string;
     direction: "asc" | "desc";
   } | null>(null);
 
+  const getSortValue = (item: T, column: ColumnDef<T>) => {
+    if (column.sortValue) {
+      return typeof column.sortValue === "function"
+        ? column.sortValue(item)
+        : item[column.sortValue];
+    }
+
+    if (typeof column.accessor === "function") {
+      return (item as Record<string, unknown>)[column.sortBy];
+    }
+
+    return item[column.accessor];
+  };
+
   const sortedData = React.useMemo(() => {
     if (sortConfig !== null) {
+      const sortColumn = columns.find((column) => column.sortBy === sortConfig.key);
+      if (!sortColumn) return data;
+
       return [...data].sort((a, b) => {
-        const aValue = a[sortConfig.key];
-        const bValue = b[sortConfig.key];
+        const aValue = getSortValue(a, sortColumn);
+        const bValue = getSortValue(b, sortColumn);
+
+        if (aValue == null && bValue == null) return 0;
+        if (aValue == null) return 1;
+        if (bValue == null) return -1;
+
         if (aValue < bValue) {
           return sortConfig.direction === "asc" ? -1 : 1;
         }
@@ -69,12 +92,15 @@ function GenericTable<T extends object>({
       });
     }
     return data;
-  }, [data, sortConfig]);
+  }, [columns, data, sortConfig]);
 
   const handleHeaderClick = (column: ColumnDef<T>) => {
     setSortConfig({
       key: column.sortBy,
-      direction: sortConfig?.direction === "asc" ? "desc" : "asc",
+      direction:
+        sortConfig?.key === column.sortBy && sortConfig.direction === "asc"
+          ? "desc"
+          : "asc",
     });
   };
 

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -15,8 +15,7 @@ import { AnimatePresence, motion } from "framer-motion";
 export type ColumnDef<T> = {
   header: string;
   accessor: keyof T | ((item: T) => React.ReactNode);
-  sortBy: string;
-  sortValue?: keyof T | ((item: T) => string | number | boolean | null | undefined);
+  sortBy: keyof T ;
 };
 
 type ActionButton<T> = {
@@ -51,37 +50,15 @@ function GenericTable<T extends object>({
   }, [data.length]);
 
   const [sortConfig, setSortConfig] = useState<{
-    key: string;
+    key: keyof T;
     direction: "asc" | "desc";
   } | null>(null);
 
-  const getSortValue = (item: T, column: ColumnDef<T>) => {
-    if (column.sortValue) {
-      return typeof column.sortValue === "function"
-        ? column.sortValue(item)
-        : item[column.sortValue];
-    }
-
-    if (typeof column.accessor === "function") {
-      return (item as Record<string, unknown>)[column.sortBy];
-    }
-
-    return item[column.accessor];
-  };
-
   const sortedData = React.useMemo(() => {
     if (sortConfig !== null) {
-      const sortColumn = columns.find((column) => column.sortBy === sortConfig.key);
-      if (!sortColumn) return data;
-
       return [...data].sort((a, b) => {
-        const aValue = getSortValue(a, sortColumn);
-        const bValue = getSortValue(b, sortColumn);
-
-        if (aValue == null && bValue == null) return 0;
-        if (aValue == null) return 1;
-        if (bValue == null) return -1;
-
+        const aValue = a[sortConfig.key];
+        const bValue = b[sortConfig.key];
         if (aValue < bValue) {
           return sortConfig.direction === "asc" ? -1 : 1;
         }
@@ -92,15 +69,12 @@ function GenericTable<T extends object>({
       });
     }
     return data;
-  }, [columns, data, sortConfig]);
+  }, [data, sortConfig]);
 
   const handleHeaderClick = (column: ColumnDef<T>) => {
     setSortConfig({
       key: column.sortBy,
-      direction:
-        sortConfig?.key === column.sortBy && sortConfig.direction === "asc"
-          ? "desc"
-          : "asc",
+      direction: sortConfig?.direction === "asc" ? "desc" : "asc",
     });
   };
 

--- a/src/pages/ui/services/components/DeploymentStatusBadge.tsx
+++ b/src/pages/ui/services/components/DeploymentStatusBadge.tsx
@@ -1,0 +1,138 @@
+import { Badge, BadgeProps } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock3,
+  OctagonAlert,
+  XCircle,
+} from "lucide-react";
+import {
+  DeploymentResourceKind,
+  DeploymentState,
+  DeploymentSummary,
+} from "../models/deployment";
+
+type DeploymentWithSummary = Partial<DeploymentSummary> | null | undefined;
+
+const DEPLOYMENT_STATE_ORDER: Record<DeploymentState, number> = {
+  failed: 0,
+  degraded: 1,
+  pending: 2,
+  unavailable: 3,
+  ready: 4,
+};
+
+export function getDeploymentStatusMeta(
+  state: DeploymentState
+): { label: string; variant: BadgeProps["variant"]; icon: JSX.Element } {
+  switch (state) {
+    case "ready":
+      return {
+        label: "Ready",
+        variant: "success",
+        icon: <CheckCircle2 className="mr-1 h-3.5 w-3.5" />,
+      };
+    case "pending":
+      return {
+        label: "Pending",
+        variant: "secondary",
+        icon: <Clock3 className="mr-1 h-3.5 w-3.5" />,
+      };
+    case "degraded":
+      return {
+        label: "Degraded",
+        variant: "default",
+        icon: <AlertCircle className="mr-1 h-3.5 w-3.5" />,
+      };
+    case "failed":
+      return {
+        label: "Failed",
+        variant: "destructive",
+        icon: <XCircle className="mr-1 h-3.5 w-3.5" />,
+      };
+    case "unavailable":
+    default:
+      return {
+        label: "Unavailable",
+        variant: "outline",
+        icon: <OctagonAlert className="mr-1 h-3.5 w-3.5" />,
+      };
+  }
+}
+
+export function formatDeploymentResourceKind(kind?: DeploymentResourceKind) {
+  switch (kind) {
+    case "exposed_service":
+      return "Exposed service";
+    case "knative_service":
+      return "Knative service";
+    case "unavailable":
+    default:
+      return "Unavailable";
+  }
+}
+
+export function getDeploymentSortValue(deployment?: DeploymentWithSummary) {
+  const state = deployment?.state ?? "unavailable";
+  return DEPLOYMENT_STATE_ORDER[state];
+}
+
+function getTooltipContent(deployment?: DeploymentWithSummary) {
+  if (!deployment) {
+    return "Deployment status not available.";
+  }
+
+  const reason = deployment.reason || "No additional reason provided.";
+  const instances = `${deployment.active_instances ?? 0} active, ${deployment.affected_instances ?? 0} affected`;
+  const runtime = formatDeploymentResourceKind(deployment.resource_kind);
+
+  return (
+    <div className="max-w-xs space-y-1">
+      <p>{reason}</p>
+      <p>{instances}</p>
+      <p>{runtime}</p>
+    </div>
+  );
+}
+
+interface Props {
+  deployment?: DeploymentWithSummary;
+  className?: string;
+  showTooltip?: boolean;
+}
+
+export default function DeploymentStatusBadge({
+  deployment,
+  className,
+  showTooltip = false,
+}: Props) {
+  const meta = getDeploymentStatusMeta(deployment?.state ?? "unavailable");
+
+  const badge = (
+    <Badge variant={meta.variant} className={className}>
+      {meta.icon}
+      {meta.label}
+    </Badge>
+  );
+
+  if (!showTooltip) {
+    return badge;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="inline-flex">{badge}</div>
+        </TooltipTrigger>
+        <TooltipContent>{getTooltipContent(deployment)}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/pages/ui/services/components/DeploymentStatusBadge.tsx
+++ b/src/pages/ui/services/components/DeploymentStatusBadge.tsx
@@ -78,11 +78,6 @@ export function formatDeploymentResourceKind(kind?: DeploymentResourceKind) {
   }
 }
 
-export function getDeploymentSortValue(deployment?: DeploymentWithSummary) {
-  const state = deployment?.state ?? "unavailable";
-  return DEPLOYMENT_STATE_ORDER[state];
-}
-
 function getTooltipContent(deployment?: DeploymentWithSummary) {
   if (!deployment) {
     return "Deployment status not available.";

--- a/src/pages/ui/services/components/ServiceDeployment/index.tsx
+++ b/src/pages/ui/services/components/ServiceDeployment/index.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
+import { Editor } from "@monaco-editor/react";
+import { AlertCircle, Loader2, RefreshCcw, XCircle } from "lucide-react";
+import getDeploymentStatusApi from "@/api/deployment/getDeploymentStatusApi";
+import getDeploymentLogsApi from "@/api/deployment/getDeploymentLogsApi";
+import { alert } from "@/lib/alert";
+import { errorMessage } from "@/lib/error";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  DeploymentLogStream,
+  DeploymentStatus,
+} from "../../models/deployment";
+import DeploymentStatusBadge, {
+  formatDeploymentResourceKind,
+} from "../DeploymentStatusBadge";
+
+const TAIL_LINE_OPTIONS = ["100", "200", "500", "1000"];
+
+function formatTimestamp(timestamp?: string) {
+  if (!timestamp) return "Not available";
+
+  return new Intl.DateTimeFormat("en-GB", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).format(new Date(timestamp));
+}
+
+function Field({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number;
+}) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+        {label}
+      </p>
+      <p className="text-sm text-slate-900">{value}</p>
+    </div>
+  );
+}
+
+function SummarySkeleton() {
+  return (
+    <Card>
+      <CardHeader>
+        <Skeleton className="h-7 w-48" />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Skeleton className="h-10 w-40" />
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <Skeleton className="h-14 w-full" />
+          <Skeleton className="h-14 w-full" />
+          <Skeleton className="h-14 w-full" />
+          <Skeleton className="h-14 w-full" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function LogsSkeleton() {
+  return (
+    <Card className="flex min-h-[420px] flex-col">
+      <CardHeader>
+        <Skeleton className="h-7 w-48" />
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col gap-4">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-[320px] w-full" />
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function ServiceDeployment() {
+  const { serviceId } = useParams();
+  const [deploymentStatus, setDeploymentStatus] =
+    useState<DeploymentStatus | null>(null);
+  const [deploymentLogs, setDeploymentLogs] =
+    useState<DeploymentLogStream | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [includeTimestamps, setIncludeTimestamps] = useState(true);
+  const [tailLines, setTailLines] = useState("200");
+
+  const serviceName = serviceId ?? "";
+
+  async function refreshDeployment() {
+    if (!serviceName) return;
+
+    setIsRefreshing(true);
+    try {
+      const [status, logs] = await Promise.all([
+        getDeploymentStatusApi(serviceName),
+        getDeploymentLogsApi(serviceName, {
+          timestamps: includeTimestamps,
+          tailLines: Number(tailLines),
+        }),
+      ]);
+
+      setDeploymentStatus(status);
+      setDeploymentLogs(logs);
+    } catch (error) {
+      console.error("Failed to fetch deployment visibility:", error);
+      alert.error(`Failed to fetch deployment visibility: ${errorMessage(error)}`);
+    } finally {
+      setIsLoading(false);
+      setIsRefreshing(false);
+    }
+  }
+
+  useEffect(() => {
+    refreshDeployment();
+  }, [serviceName, includeTimestamps, tailLines]);
+
+  const logsContent = useMemo(() => {
+    if (!deploymentLogs?.available) return "";
+
+    return deploymentLogs.entries
+      .map((entry) =>
+        entry.timestamp ? `${entry.timestamp} ${entry.message}` : entry.message
+      )
+      .join("\n");
+  }, [deploymentLogs]);
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 overflow-auto p-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-slate-950">
+            Deployment visibility
+          </h2>
+          <p className="text-sm text-slate-500">
+            Inspect the current deployment state and the latest deployment logs
+            for this service.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-2">
+            <Label htmlFor="deployment-timestamps">Timestamps</Label>
+            <Switch
+              id="deployment-timestamps"
+              checked={includeTimestamps}
+              onCheckedChange={setIncludeTimestamps}
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Label>Tail lines</Label>
+            <Select value={tailLines} onValueChange={setTailLines}>
+              <SelectTrigger className="w-[110px]">
+                <SelectValue placeholder="Tail lines" />
+              </SelectTrigger>
+              <SelectContent>
+                {TAIL_LINE_OPTIONS.map((value) => (
+                  <SelectItem key={value} value={value}>
+                    {value}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Button
+            variant="outline"
+            onClick={refreshDeployment}
+            disabled={isRefreshing || !serviceName}
+          >
+            <RefreshCcw
+              className={`mr-2 h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
+            />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <>
+          <SummarySkeleton />
+          <LogsSkeleton />
+        </>
+      ) : (
+        <>
+          <Card>
+            <CardHeader>
+              <CardTitle>Current deployment status</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-5">
+              {deploymentStatus ? (
+                <>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <DeploymentStatusBadge
+                      deployment={deploymentStatus}
+                      className="text-sm"
+                    />
+                    <span className="text-sm text-slate-500">
+                      Runtime: {formatDeploymentResourceKind(deploymentStatus.resource_kind)}
+                    </span>
+                  </div>
+
+                  <Alert>
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>Status reason</AlertTitle>
+                    <AlertDescription>
+                      {deploymentStatus.reason || "No additional reason provided."}
+                    </AlertDescription>
+                  </Alert>
+
+                  <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                    <Field
+                      label="Service"
+                      value={deploymentStatus.service_name}
+                    />
+                    <Field
+                      label="Namespace"
+                      value={deploymentStatus.namespace || "Not available"}
+                    />
+                    <Field
+                      label="Active instances"
+                      value={deploymentStatus.active_instances}
+                    />
+                    <Field
+                      label="Affected instances"
+                      value={deploymentStatus.affected_instances}
+                    />
+                    <Field
+                      label="Last transition"
+                      value={formatTimestamp(
+                        deploymentStatus.last_transition_time
+                      )}
+                    />
+                  </div>
+                </>
+              ) : (
+                <Alert variant="destructive">
+                  <XCircle className="h-4 w-4" />
+                  <AlertTitle>Status unavailable</AlertTitle>
+                  <AlertDescription>
+                    The deployment status could not be loaded for this service.
+                  </AlertDescription>
+                </Alert>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="flex min-h-[420px] flex-col">
+            <CardHeader>
+              <CardTitle>Deployment logs</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-1 flex-col gap-4">
+              {deploymentLogs?.message && (
+                <Alert>
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertTitle>Log stream message</AlertTitle>
+                  <AlertDescription>{deploymentLogs.message}</AlertDescription>
+                </Alert>
+              )}
+
+              {!deploymentLogs?.available ? (
+                <div className="flex flex-1 items-center justify-center rounded-lg border border-dashed border-slate-300 bg-slate-50 p-6 text-center text-sm text-slate-500">
+                  {deploymentLogs?.message ||
+                    "Deployment logs are not available for this service."}
+                </div>
+              ) : (
+                <div className="relative flex-1 overflow-hidden rounded-lg border border-slate-200">
+                  {isRefreshing && (
+                    <div className="absolute right-3 top-3 z-10 rounded-md bg-white/90 px-2 py-1 text-xs text-slate-500 shadow-sm">
+                      <span className="inline-flex items-center gap-1">
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        Refreshing
+                      </span>
+                    </div>
+                  )}
+                  <Editor
+                    height="100%"
+                    defaultLanguage="shell"
+                    value={logsContent}
+                    options={{
+                      readOnly: true,
+                      minimap: { enabled: false },
+                      wordWrap: "on",
+                      scrollBeyondLastLine: false,
+                      fontSize: 13,
+                    }}
+                  />
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/ui/services/components/ServicesList/index.tsx
+++ b/src/pages/ui/services/components/ServicesList/index.tsx
@@ -5,8 +5,9 @@ import deleteServiceApi from "@/api/services/deleteServiceApi";
 import { alert } from "@/lib/alert";
 import DeleteDialog from "@/components/DeleteDialog";
 import { Service } from "../../models/service";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { LoaderPinwheel, Pencil, Terminal, Trash2 } from "lucide-react";
+import { LoaderPinwheel, Pencil, RefreshCw, Terminal, Trash2 } from "lucide-react";
 import OscarColors from "@/styles";
 import { Link, useNavigate } from "react-router-dom";
 import GenericTable from "@/components/Table";
@@ -19,6 +20,58 @@ import { errorMessage } from "@/lib/error";
 import DeploymentStatusBadge, {
   getDeploymentSortValue,
 } from "../DeploymentStatusBadge";
+import getDeploymentStatusApi from "@/api/deployment/getDeploymentStatusApi";
+import { DeploymentStatus } from "../../models/deployment";
+
+interface DeploymentStatusCellProps {
+  initialDeployment?: DeploymentStatus;
+  serviceName: string;
+  onNavigate: () => void;
+}
+
+function DeploymentStatusCell({ initialDeployment, serviceName, onNavigate }: DeploymentStatusCellProps) {
+  const [deployment, setDeployment] = useState<DeploymentStatus | undefined>(initialDeployment);
+  const [loading, setLoading] = useState(false);
+
+  async function fetchDeployment() {
+    setLoading(true);
+    try {
+      const result = await getDeploymentStatusApi(serviceName);
+      setDeployment(result);
+    } catch {
+      // leave existing state on error
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div
+      className="flex items-center gap-1 cursor-pointer"
+      onClick={(e) => {
+        e.stopPropagation();
+        fetchDeployment();
+      }}
+    >
+      {deployment && !loading ? (
+        <>
+        <div onClick={(e) => {
+          e.stopPropagation();
+          onNavigate();
+        }}>
+          <DeploymentStatusBadge deployment={deployment} showTooltip className="cursor-pointer" />
+        </div>
+          <RefreshCw className="h-3 w-3 opacity-40 hover:opacity-100" />
+        </>
+      ) : (
+        <Badge variant="default" className="cursor-pointer">
+          <RefreshCw className={`${loading ? "animate-spin" : ""} h-3 w-3 mr-1`} />
+          Fetch
+        </Badge>
+      )}
+    </div>
+  );
+}
 
 function ServicesList() {
   const { services, servicesAreLoading, setServices, setFormService, filter } =
@@ -30,7 +83,7 @@ function ServicesList() {
 
   async function handleGetServices() {
     try {
-      const response = await getServicesApi({ includeDeployment: true });
+      const response = await getServicesApi();
       setServices(response);
     } catch (error) {
       alert.error(`Error getting services: ${errorMessage(error)}`);
@@ -117,31 +170,22 @@ function ServicesList() {
           <GenericTable<Service>
             data={filteredServices}
             idKey="name"
-            onRowClick={(item) => {
-              setFormService(item);
-              navigate(`/ui/services/${item.name}/settings`);
-            }}
             columns={[
               { header: "Name", accessor: "name", sortBy: "name" },
               {
                 header: "Deployment",
                 accessor: (row) => (
-                  <div
-                    onClick={(event) => {
-                      event.stopPropagation();
+                  <DeploymentStatusCell
+                    initialDeployment={row.deployment as DeploymentStatus}
+                    serviceName={row.name}
+                    onNavigate={() => {
                       setFormService(row);
                       navigate(`/ui/services/${row.name}/deployment`);
                     }}
-                  >
-                    <DeploymentStatusBadge
-                      deployment={row.deployment}
-                      showTooltip
-                      className="cursor-pointer"
-                    />
-                  </div>
+                  />
                 ),
                 sortBy: "deployment",
-                sortValue: (row) => getDeploymentSortValue(row.deployment),
+                sortValue: (row) => getDeploymentSortValue(row.deployment as DeploymentStatus),
               },
               { header: "Owner", accessor: (row) => (<ResponsiveOwnerField owner={row.owner} copy={false} />), sortBy: "owner" },
               { header: "Image", accessor: "image", sortBy: "image" },

--- a/src/pages/ui/services/components/ServicesList/index.tsx
+++ b/src/pages/ui/services/components/ServicesList/index.tsx
@@ -17,9 +17,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import MoreActionsPopover from "./components/MoreActionsPopover";
 import ResponsiveOwnerField from "@/components/ResponsiveOwnerField";
 import { errorMessage } from "@/lib/error";
-import DeploymentStatusBadge, {
-  getDeploymentSortValue,
-} from "../DeploymentStatusBadge";
+import DeploymentStatusBadge from "../DeploymentStatusBadge";
 import getDeploymentStatusApi from "@/api/deployment/getDeploymentStatusApi";
 import { DeploymentStatus } from "../../models/deployment";
 import ServiceRedirectButton from "@/components/ServiceRedirectButton";
@@ -185,7 +183,6 @@ function ServicesList() {
                   />
                 ),
                 sortBy: "deployment",
-                sortValue: (row) => getDeploymentSortValue(row.deployment as DeploymentStatus),
               },
               { header: "Owner", accessor: (row) => (<ResponsiveOwnerField owner={row.labels["owner_name"] ? shortenFullname(row.labels["owner_name"]) : row.owner} sub={row.owner} />), sortBy: "owner" },
               { header: "Image", accessor: "image", sortBy: "image" },

--- a/src/pages/ui/services/components/ServicesList/index.tsx
+++ b/src/pages/ui/services/components/ServicesList/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import useServicesContext from "../../context/ServicesContext";
 import getServicesApi from "@/api/services/getServicesApi";
 import deleteServiceApi from "@/api/services/deleteServiceApi";
@@ -16,6 +16,9 @@ import { useAuth } from "@/contexts/AuthContext";
 import MoreActionsPopover from "./components/MoreActionsPopover";
 import ResponsiveOwnerField from "@/components/ResponsiveOwnerField";
 import { errorMessage } from "@/lib/error";
+import DeploymentStatusBadge, {
+  getDeploymentSortValue,
+} from "../DeploymentStatusBadge";
 
 function ServicesList() {
   const { services, servicesAreLoading, setServices, setFormService, filter } =
@@ -27,7 +30,7 @@ function ServicesList() {
 
   async function handleGetServices() {
     try {
-      const response = await getServicesApi();
+      const response = await getServicesApi({ includeDeployment: true });
       setServices(response);
     } catch (error) {
       alert.error(`Error getting services: ${errorMessage(error)}`);
@@ -55,7 +58,7 @@ function ServicesList() {
         .map((result) => (result as {
           status: string;
           service: Service;
-          error: any;
+          error: unknown;
         }).service);
       
       await handleGetServices();
@@ -89,6 +92,12 @@ function ServicesList() {
     return filteredServices;
   }, [services, filter, authData?.user]);
 
+  useEffect(() => {
+    if (services.length === 0 || services.some((service) => !service.deployment)) {
+      handleGetServices();
+    }
+  }, []);
+
   return (
     <div
       style={{
@@ -114,6 +123,26 @@ function ServicesList() {
             }}
             columns={[
               { header: "Name", accessor: "name", sortBy: "name" },
+              {
+                header: "Deployment",
+                accessor: (row) => (
+                  <div
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setFormService(row);
+                      navigate(`/ui/services/${row.name}/deployment`);
+                    }}
+                  >
+                    <DeploymentStatusBadge
+                      deployment={row.deployment}
+                      showTooltip
+                      className="cursor-pointer"
+                    />
+                  </div>
+                ),
+                sortBy: "deployment",
+                sortValue: (row) => getDeploymentSortValue(row.deployment),
+              },
               { header: "Owner", accessor: (row) => (<ResponsiveOwnerField owner={row.owner} copy={false} />), sortBy: "owner" },
               { header: "Image", accessor: "image", sortBy: "image" },
               { header: "CPU", accessor: "cpu", sortBy: "cpu" },

--- a/src/pages/ui/services/components/Topbar/components/CreateUpdateServiceTabs.tsx
+++ b/src/pages/ui/services/components/Topbar/components/CreateUpdateServiceTabs.tsx
@@ -47,6 +47,10 @@ function CreateUpdateServiceTabs({ mode }: Props) {
               <Button variant={getVariant("settings")}>Settings</Button>
             </Link>
 
+            <Link to={`/ui/services/${serviceId}/deployment`}>
+              <Button variant={getVariant("deployment")}>Deployment</Button>
+            </Link>
+
             <Link to={`/ui/services/${serviceId}/logs`}>
               <Button variant={getVariant("logs")}>Logs</Button>
             </Link>

--- a/src/pages/ui/services/components/Topbar/index.tsx
+++ b/src/pages/ui/services/components/Topbar/index.tsx
@@ -15,22 +15,46 @@ export enum ServiceViewMode {
 function ServicesTopbar() {
   const { formMode, refreshServices, refreshServiceLogs } = useServicesContext();
 
+  function getCurrentSubview() {
+    const location = window.location.hash.split("/");
+    return location[location.length - 1];
+  }
+
   function getDefaultHeader(formMode: ServiceViewMode) {
     switch (formMode) {
       case ServiceViewMode.List:
         return { title: "Services", linkTo: "/ui/services" };
-      case ServiceViewMode.Update:
-        const location = window.location.hash.split("/");
-        const header = location[location.length - 1];
-        const linkTo = window.location.hash.replace('#', '');
+      case ServiceViewMode.Update: {
+        const header = getCurrentSubview();
+        const linkTo = window.location.hash.replace("#", "");
 
         if (header === "logs") {
           return { title: "Logs", linkTo: linkTo };
         }
+        if (header === "deployment") {
+          return { title: "Deployment", linkTo: linkTo };
+        }
         return { title: "Services", linkTo: "/ui/services" };
+      }
       default:
         return { title: "Services", linkTo: "/ui/services" };
     }
+  }
+
+  function getRefresher() {
+    if (formMode === ServiceViewMode.List) {
+      return refreshServices;
+    }
+
+    const header = getCurrentSubview();
+    if (header === "logs") {
+      return refreshServiceLogs;
+    }
+    if (header === "settings") {
+      return refreshServices;
+    }
+
+    return undefined;
   }
 
   useEffect(() => {
@@ -40,7 +64,7 @@ function ServicesTopbar() {
   return (
     <GenericTopbar
       defaultHeader={getDefaultHeader(formMode)}
-      refresher={formMode === ServiceViewMode.List ? refreshServices : refreshServiceLogs}
+      refresher={getRefresher()}
       secondaryRow={
         formMode === ServiceViewMode.List ? 
         <div className="w-full p-2 pt-1">

--- a/src/pages/ui/services/context/ServicesContext.tsx
+++ b/src/pages/ui/services/context/ServicesContext.tsx
@@ -177,7 +177,9 @@ export const ServicesProvider = ({
 
   async function handleGetServices() {
     setServicesAreLoading(true);
-    const response = await getServicesApi();
+    const response = await getServicesApi({
+      includeDeployment: formMode === ServiceViewMode.List,
+    });
     setServicesAreLoading(false);
 
     setServices(response);

--- a/src/pages/ui/services/context/ServicesContext.tsx
+++ b/src/pages/ui/services/context/ServicesContext.tsx
@@ -177,9 +177,7 @@ export const ServicesProvider = ({
 
   async function handleGetServices() {
     setServicesAreLoading(true);
-    const response = await getServicesApi({
-      includeDeployment: formMode === ServiceViewMode.List,
-    });
+    const response = await getServicesApi();
     setServicesAreLoading(false);
 
     setServices(response);

--- a/src/pages/ui/services/models/deployment.ts
+++ b/src/pages/ui/services/models/deployment.ts
@@ -1,0 +1,37 @@
+export type DeploymentState =
+  | "pending"
+  | "ready"
+  | "degraded"
+  | "failed"
+  | "unavailable";
+
+export type DeploymentResourceKind =
+  | "exposed_service"
+  | "knative_service"
+  | "unavailable";
+
+export interface DeploymentSummary {
+  state: DeploymentState;
+  reason?: string;
+  last_transition_time?: string;
+  active_instances: number;
+  affected_instances: number;
+  resource_kind: DeploymentResourceKind;
+}
+
+export interface DeploymentStatus extends DeploymentSummary {
+  service_name: string;
+  namespace?: string;
+}
+
+export interface DeploymentLogEntry {
+  timestamp?: string;
+  message: string;
+}
+
+export interface DeploymentLogStream {
+  service_name: string;
+  available: boolean;
+  message?: string;
+  entries: DeploymentLogEntry[];
+}

--- a/src/pages/ui/services/models/service.ts
+++ b/src/pages/ui/services/models/service.ts
@@ -1,3 +1,5 @@
+import { DeploymentSummary } from "./deployment";
+
 export type ServiceFilter = {
   value: string;
   type: ServiceFilterBy;
@@ -170,6 +172,7 @@ export interface Service {
     path: string;
     storage_provider: string;
   };
+  deployment?: DeploymentSummary;
   expose: {
     min_scale: string,
     max_scale: string,

--- a/src/pages/ui/services/router.tsx
+++ b/src/pages/ui/services/router.tsx
@@ -4,6 +4,7 @@ import ServicesList from "./components/ServicesList";
 import ServiceForm from "./components/ServiceForm";
 import FDLForm from "./components/FDL";
 import ServiceLogs from "./components/ServiceLogs";
+import ServiceDeployment from "./components/ServiceDeployment";
 
 function ServicesRouter() {
   return (
@@ -28,6 +29,7 @@ function ServicesRouter() {
         <Route path="" element={<ServicesList />} />
         <Route path=":serviceId" element={<ServiceForm />} />
         <Route path=":serviceId/settings" element={<ServiceForm />} />
+        <Route path=":serviceId/deployment" element={<ServiceDeployment />} />
         <Route path=":serviceId/logs" element={<ServiceLogs />} />
       </Route>
     </Routes>


### PR DESCRIPTION
## What changed

This branch adds support in the dashboard for the deployment visibility APIs introduced in OSCAR.

### Deployment detail view
- Added a new `Deployment` tab in the service detail view.
- Added a dedicated deployment screen with:
  - current deployment status
  - status reason
  - runtime kind
  - active / affected instances
  - last transition timestamp
  - deployment logs viewer
  - refresh, timestamp toggle, and tail-lines selection

### Services list integration
- Added a new `Deployment` column in the services table.
- The list now requests `GET /system/services?include=deployment` when needed.
- Deployment state is shown as a compact badge with tooltip details.
- Clicking the badge navigates to the deployment detail view.

### Shared UI / data layer
- Added typed frontend models for deployment status and deployment logs.
- Added API helpers for:
  - `GET /system/services/:serviceName/deployment`
  - `GET /system/services/:serviceName/deployment/logs`
- Extracted a reusable deployment status badge component shared by list and detail views.

### Table / behavior fixes
- Extended the generic table to support sorting by derived values.
- Fixed sorting so existing function-rendered columns do not regress.
- Ensured the services list reloads deployment data correctly after route transitions.

## Validation

- `npm run build` passes.
- Targeted `eslint` checks for the modified services/table files pass.

## Notes

- Existing unrelated lint issues remain outside this branch in other areas of the repo.
- Local changes already present in `src/env.ts` were not modified by this work.
