### PR TITLE
Feat deployment status logs dashboard

### DIFF
--- a/src/pages/ui/services/components/DeploymentStatusBadge.tsx
+++ b/src/pages/ui/services/components/DeploymentStatusBadge.tsx
@@ -20,14 +20,6 @@ import {
 
 type DeploymentWithSummary = Partial<DeploymentSummary> | null | undefined;
 
-const DEPLOYMENT_STATE_ORDER: Record<DeploymentState, number> = {
-  failed: 0,
-  degraded: 1,
-  pending: 2,
-  unavailable: 3,
-  ready: 4,
-};
-
 export function getDeploymentStatusMeta(
   state: DeploymentState
 ): { label: string; variant: BadgeProps["variant"]; icon: JSX.Element } {

--- a/src/pages/ui/services/components/ServicesList/index.tsx
+++ b/src/pages/ui/services/components/ServicesList/index.tsx
@@ -27,9 +27,10 @@ interface DeploymentStatusCellProps {
   initialDeployment?: DeploymentStatus;
   serviceName: string;
   onNavigate: () => void;
+  eagerLoad?: boolean;
 }
 
-function DeploymentStatusCell({ initialDeployment, serviceName, onNavigate }: DeploymentStatusCellProps) {
+function DeploymentStatusCell({ initialDeployment, serviceName, onNavigate, eagerLoad }: DeploymentStatusCellProps) {
   const [deployment, setDeployment] = useState<DeploymentStatus | undefined>(initialDeployment);
   const [loading, setLoading] = useState(false);
 
@@ -44,6 +45,12 @@ function DeploymentStatusCell({ initialDeployment, serviceName, onNavigate }: De
       setLoading(false);
     }
   }
+
+  useEffect(() => {
+    if (eagerLoad && !initialDeployment) {
+      fetchDeployment();
+    }
+  }, [eagerLoad]);
 
   return (
     <div
@@ -72,7 +79,7 @@ function DeploymentStatusCell({ initialDeployment, serviceName, onNavigate }: De
 }
 
 function ServicesList() {
-  const { services, servicesAreLoading, setServices, setFormService, filter } =
+  const { services, servicesAreLoading, setServices, setFormService, filter, eagerLoadDeployment } =
     useServicesContext();
   const { authData } = useAuth();
   const [servicesToDelete, setServicesToDelete] = useState<Service[]>([]);
@@ -176,6 +183,7 @@ function ServicesList() {
                   <DeploymentStatusCell
                     initialDeployment={row.deployment as DeploymentStatus}
                     serviceName={row.name}
+                    eagerLoad={eagerLoadDeployment}
                     onNavigate={() => {
                       setFormService(row);
                       navigate(`/ui/services/${row.name}/deployment`);

--- a/src/pages/ui/services/components/Topbar/index.tsx
+++ b/src/pages/ui/services/components/Topbar/index.tsx
@@ -5,6 +5,17 @@ import AddServiceButton from "./components/CreateServiceButton";
 import CreateUpdateServiceTabs from "./components/CreateUpdateServiceTabs";
 import useServicesContext from "../../context/ServicesContext";
 import GenericTopbar from "@/components/Topbar";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Settings2 } from "lucide-react";
 
 export enum ServiceViewMode {
   List = "List",
@@ -13,7 +24,7 @@ export enum ServiceViewMode {
 }
 
 function ServicesTopbar() {
-  const { formMode, refreshServices, refreshServiceLogs } = useServicesContext();
+  const { formMode, refreshServices, refreshServiceLogs, eagerLoadDeployment, setEagerLoadDeployment } = useServicesContext();
 
   function getCurrentSubview() {
     const location = window.location.hash.split("/");
@@ -67,8 +78,30 @@ function ServicesTopbar() {
       refresher={getRefresher()}
       secondaryRow={
         formMode === ServiceViewMode.List ? 
-        <div className="w-full p-2 pt-1">
+        <div className="w-full p-2 pt-1 flex items-center gap-2">
           <ServicesFilterBy />
+          {/* Options dropdown for services */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="icon" className="shrink-0" tooltipLabel="Options">
+                <Settings2 className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuLabel>Display options</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <div className="flex items-center justify-between px-2 py-1.5">
+                <Label htmlFor="eager-load-deployment" className="text-sm cursor-pointer">
+                  Auto-load deployment status
+                </Label>
+                <Switch
+                  id="eager-load-deployment"
+                  checked={eagerLoadDeployment}
+                  onCheckedChange={setEagerLoadDeployment}
+                />
+              </div>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
         : null
       }

--- a/src/pages/ui/services/context/ServicesContext.tsx
+++ b/src/pages/ui/services/context/ServicesContext.tsx
@@ -45,6 +45,9 @@ interface ServiceContextType {
   refreshServices: () => void;
   formMode: ServiceViewMode;
 
+  eagerLoadDeployment: boolean;
+  setEagerLoadDeployment: Dispatch<SetStateAction<boolean>>;
+
   refreshServiceLogs: () => void;
   serviceLogs: {next_page: string | null, jobs: Record<string, Log>};
   formFunctions: FormFunctions;
@@ -83,6 +86,9 @@ export const ServicesProvider = ({
 }) => {
   const [services, setServices] = useState([] as Service[]);
   const [servicesAreLoading, setServicesAreLoading] = useState(false);
+  const [eagerLoadDeployment, setEagerLoadDeployment] = useState(() => {
+    return localStorage.getItem("eagerLoadDeployment") === "true";
+  });
   const [serviceLogs, setServiceLogs] = useState<{next_page: string | null, jobs: Record<string, Log>}>({next_page: null, jobs: {}});
   const [logsAreLoading, setLogsAreLoading] = useState(true);
   const [showFDLModal, setShowFDLModal] = useState(false);
@@ -216,6 +222,10 @@ export const ServicesProvider = ({
     handleGetServices();
   }, []);
 
+  useEffect(() => {
+    localStorage.setItem("eagerLoadDeployment", String(eagerLoadDeployment));
+  }, [eagerLoadDeployment]);
+
   useUpdate(() => {
     handleFormService(services);
   }, [serviceId]);
@@ -237,6 +247,8 @@ export const ServicesProvider = ({
         showFDLModal,
         setShowFDLModal,
         refreshServices: handleGetServices,
+        eagerLoadDeployment,
+        setEagerLoadDeployment,
         serviceLogs,
         refreshServiceLogs: handleGetServiceLogs,
         formFunctions: {


### PR DESCRIPTION
**Feature: Eager Deployment Status Loading**

* Added `eagerLoadDeployment` boolean and its setter to the `ServicesContext`, initializing from and persisting to local storage, allowing the setting to persist across sessions.
* Passed the `eagerLoadDeployment` context value through to each `DeploymentStatusCell` in the services list. 

**UI Enhancements**

* Added a dropdown menu to the services top bar with a toggle switch for "Auto-load deployment status", allowing users to enable or disable the eager loading feature from the UI. 
