### PR TITLE
Improve synchronous ZIP response handling in invoke dialog

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -381,7 +381,7 @@ export function detectBinaryMimeType(bytes: Uint8Array): string | null {
     }
   }
 
-  return "application/octet-stream";
+  return "text/plain";
 }
 
 export function addItemToPosition(array: any[], item: any, position: number, countFromLast: boolean = false): any[] {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -303,6 +303,87 @@ export function isFileBase64(content: string): boolean {
   }
 }
 
+export function extractBase64Payload(content: string): string | null {
+  const base64LinePattern =
+    /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+  const normalizedLines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/\s+/g, ""))
+    .filter(Boolean);
+
+  const payloadLines: string[] = [];
+  for (let i = normalizedLines.length - 1; i >= 0; i -= 1) {
+    const line = normalizedLines[i];
+    if (base64LinePattern.test(line)) {
+      payloadLines.unshift(line);
+      continue;
+    }
+    if (payloadLines.length > 0) {
+      break;
+    }
+  }
+
+  const candidate = payloadLines.join("");
+  if (!candidate || candidate.length < 32 || candidate.length % 4 !== 0) {
+    return null;
+  }
+
+  try {
+    atob(candidate);
+    return candidate;
+  } catch (_error) {
+    return null;
+  }
+
+}
+
+export function decodeBase64ToBytes(content: string): Uint8Array | null {
+  try {
+    const decoded = atob(content);
+    return Uint8Array.from(decoded, (char) => char.charCodeAt(0));
+  } catch (_error) {
+    return null;
+  }
+}
+
+export function detectBinaryMimeType(bytes: Uint8Array): string | null {
+  if (bytes.length >= 4) {
+    if (
+      bytes[0] === 0x50 &&
+      bytes[1] === 0x4b &&
+      (bytes[2] === 0x03 || bytes[2] === 0x05 || bytes[2] === 0x07) &&
+      (bytes[3] === 0x04 || bytes[3] === 0x06 || bytes[3] === 0x08)
+    ) {
+      return "application/zip";
+    }
+    if (
+      bytes[0] === 0x89 &&
+      bytes[1] === 0x50 &&
+      bytes[2] === 0x4e &&
+      bytes[3] === 0x47
+    ) {
+      return "image/png";
+    }
+    if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+      return "image/jpeg";
+    }
+    if (bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46) {
+      return "image/gif";
+    }
+    if (
+      bytes[0] === 0x25 &&
+      bytes[1] === 0x50 &&
+      bytes[2] === 0x44 &&
+      bytes[3] === 0x46
+    ) {
+      return "application/pdf";
+    }
+  }
+
+  return "application/octet-stream";
+}
+
 export function addItemToPosition(array: any[], item: any, position: number, countFromLast: boolean = false): any[] {
   if (countFromLast) {
     position = array.length - position;

--- a/src/pages/ui/services/components/InvokePopover/index.tsx
+++ b/src/pages/ui/services/components/InvokePopover/index.tsx
@@ -244,7 +244,7 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
   };
 
   const renderUploadView = () => (
-    <div className="grid grid-cols-1 w-full">
+    <div className="grid grid-cols-1 w-full overflow-y-auto">
       {!file ? (
         <>
           <input
@@ -581,7 +581,7 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
 
   const renderResponseView = () => {
     return (
-      <div className="grid grid-cols-1 grid-rows-[auto_1fr] w-full gap-2">
+      <div className="grid grid-cols-1 grid-rows-[auto_1fr] w-full h-full gap-2 min-h-0">
         <Select
           value={responseType}
           onValueChange={(value) =>
@@ -606,17 +606,10 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
               )}
           </SelectContent>
         </Select>
-        <div className="h-full">
+        <div className="h-full w-full min-h-0">
           {responseType === "text" && (
             <div
-              style={{
-                overflow: "auto",
-                padding: "0px 10px",
-                whiteSpace: "pre-wrap",
-                wordWrap: "break-word",
-                overflowWrap: "break-word",
-                maxHeight: "75vh",
-              }}
+              className="h-full overflow-y-auto whitespace-pre-wrap break-words"
             >
               {response}
             </div>
@@ -629,16 +622,13 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
           )}
           {responseType === "file" && (
             <div
-              style={{
-                padding: "0px 10px",
-                whiteSpace: "pre-wrap",
-                wordWrap: "break-word",
-                overflowWrap: "break-word",
-              }}
+              className="h-full w-full min-h-0"
             >
+              <div className="overflow-y-auto whitespace-pre-wrap break-words h-full w-full min-h-0">
               {responseFileContent}
+              </div>
               {responseDownloadUrl && (
-                <div className="mt-4">
+                <div className="mt-5">
                   <Button variant="outline" onClick={handleDownloadResponse}>
                     <Download className="h-4 w-4 mr-2" />
                     Download file
@@ -648,7 +638,7 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
             </div>
           )}
           {responseType === "zip" && (
-            <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-4 h-full min-h-0">
+            <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-4 h-full min-h-0 overflow-y-auto">
               <div className="border rounded-md overflow-hidden min-h-[220px]">
                 <div className="flex items-center justify-between p-3 border-b bg-muted/50">
                   <div>
@@ -789,7 +779,7 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
           </Button>
         )}
       </DialogTrigger>
-      <DialogContent className="grid grid-cols-1 grid-rows-[auto_1fr_auto] w-screen sm:w-[70%] 2xl:w-[60%] h-[90%] sm:h-[80%] 2xl:h-[60%] overflow-y-auto gap-5">
+      <DialogContent className="grid grid-cols-1 grid-rows-[auto_1fr_auto] w-screen sm:w-[70%] 2xl:w-[60%] h-[90%] sm:h-[80%] 2xl:h-[60%] gap-5">
         <DialogHeader>
           <DialogTitle>
             <span style={{ color: OscarColors.DarkGrayText }}>

--- a/src/pages/ui/services/components/InvokePopover/index.tsx
+++ b/src/pages/ui/services/components/InvokePopover/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import JSZip from "jszip";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -18,6 +19,7 @@ import {
   Trash2,
   ArrowRight,
   Terminal,
+  Download,
 } from "lucide-react";
 import {
   Select,
@@ -33,10 +35,23 @@ import OscarColors from "@/styles";
 import { useAuth } from "@/contexts/AuthContext";
 import RequestButton from "@/components/RequestButton";
 import invokeServiceSync from "@/api/invoke/invokeServiceSync";
-import { isFileBase64 } from "@/lib/utils";
+import {
+  decodeBase64ToBytes,
+  detectBinaryMimeType,
+  extractBase64Payload,
+} from "@/lib/utils";
+import { getMimeTypeFromPath } from "@/lib/mimeType";
 import { errorMessage } from "@/lib/error";
 
 type View = "upload" | "editor" | "response";
+type ResponseType = "text" | "image" | "file" | "zip";
+type ZipPreviewType = "text" | "image" | "pdf" | "other";
+
+interface ZipEntryPreview {
+  name: string;
+  mimeType: string;
+  previewType: ZipPreviewType;
+}
 
 interface Props {
   service?: Service;
@@ -56,10 +71,39 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [selectedLanguage, setSelectedLanguage] = useState<string>("plaintext");
   const [response, setResponse] = useState<string>("");
+  const [responsePayloadBase64, setResponsePayloadBase64] = useState<string>("");
+  const [responsePayloadMimeType, setResponsePayloadMimeType] = useState<string>("");
+  const [responseDownloadUrl, setResponseDownloadUrl] = useState<string>("");
+  const [responseDownloadName, setResponseDownloadName] = useState<string>("");
+  const [zipArchive, setZipArchive] = useState<JSZip | null>(null);
+  const [zipEntries, setZipEntries] = useState<ZipEntryPreview[]>([]);
+  const [selectedZipEntryName, setSelectedZipEntryName] = useState<string>("");
+  const [zipPreviewType, setZipPreviewType] = useState<ZipPreviewType>("other");
+  const [zipPreviewText, setZipPreviewText] = useState<string>("");
+  const [zipPreviewUrl, setZipPreviewUrl] = useState<string>("");
+  const [zipPreviewLoading, setZipPreviewLoading] = useState<boolean>(false);
 
-  const [responseType, setResponseType] = useState<"text" | "image" | "file">(
-    "text"
-  );
+  const [responseType, setResponseType] = useState<ResponseType>("text");
+
+  const getBlobData = (bytes: Uint8Array) =>
+    bytes.buffer instanceof ArrayBuffer
+      ? bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+      : Uint8Array.from(bytes).buffer;
+
+  const getZipEntryPreviewType = (mimeType: string): ZipPreviewType => {
+    if (mimeType.startsWith("image/")) return "image";
+    if (mimeType === "application/pdf") return "pdf";
+    if (
+      mimeType.startsWith("text/") ||
+      mimeType === "application/json" ||
+      mimeType === "application/xml" ||
+      mimeType === "application/yaml" ||
+      mimeType === "application/javascript"
+    ) {
+      return "text";
+    }
+    return "other";
+  };
 
   const handleFileUpload = (uploadedFile: File) => {
     setFile(uploadedFile);
@@ -128,13 +172,57 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
       });
       const responseString = responseLocal as string;
       setResponse(responseString);
+      setResponsePayloadBase64("");
+      setResponsePayloadMimeType("");
+      setResponseDownloadName("");
+      setZipArchive(null);
+      setZipEntries([]);
+      setSelectedZipEntryName("");
+
       if (responseString.trim() !== "") {
         if (responseString.startsWith("data:image/")) {
+          const [dataUriPrefix, dataUriPayload = ""] = responseString.split(",");
+          const mimeType = dataUriPrefix
+            .replace(/^data:/, "")
+            .replace(/;base64$/, "");
+          setResponsePayloadBase64(dataUriPayload);
+          setResponsePayloadMimeType(mimeType);
           setResponseType("image");
-        } else if (isFileBase64(responseString)) {
-          setResponseType("file");
         } else {
-          setResponseType("text");
+          const base64Payload = extractBase64Payload(responseString);
+          const bytes = base64Payload
+            ? decodeBase64ToBytes(base64Payload)
+            : null;
+          const mimeType = bytes ? detectBinaryMimeType(bytes) : null;
+
+          if (
+            base64Payload &&
+            bytes &&
+            mimeType &&
+            mimeType !== "application/octet-stream"
+          ) {
+            setResponsePayloadBase64(base64Payload);
+            setResponsePayloadMimeType(mimeType);
+            if (mimeType === "application/zip") {
+              setResponseDownloadName(`${currentService?.name ?? "response"}.zip`);
+              setResponseType("zip");
+            } else if (mimeType.startsWith("image/")) {
+              setResponseType("image");
+            } else {
+              const extension =
+                mimeType === "application/pdf"
+                  ? "pdf"
+                  : mimeType.startsWith("text/")
+                    ? "txt"
+                    : "bin";
+              setResponseDownloadName(
+                `${currentService?.name ?? "response"}.${extension}`
+              );
+              setResponseType("file");
+            }
+          } else {
+            setResponseType("text");
+          }
         }
       }
       setCurrentView("response");
@@ -241,16 +329,223 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
 
   const [responseFileContent, setResponseFileContent] = useState<string>("");
   useEffect(() => {
+    if (!responsePayloadBase64) {
+      setResponseFileContent("");
+      return;
+    }
+
+    const bytes = decodeBase64ToBytes(responsePayloadBase64);
+    if (!bytes) {
+      setResponseFileContent(response);
+      return;
+    }
+
     if (responseType === "file") {
       try {
-        const base64 = response.split("\n")[0];
-        const decodedContent = atob(base64);
+        const decodedContent = new TextDecoder().decode(bytes);
         setResponseFileContent(decodedContent);
       } catch (error) {
-        setResponseFileContent(response);
-      }      
+        setResponseFileContent("Binary file ready to download.");
+      }
     }
-  }, [responseType]);
+
+    if (responseType === "zip") {
+      setResponseFileContent("ZIP file ready to download.");
+    }
+  }, [response, responsePayloadBase64, responseType]);
+
+  useEffect(() => {
+    if (!responsePayloadBase64 || !responsePayloadMimeType) {
+      if (responseDownloadUrl) {
+        URL.revokeObjectURL(responseDownloadUrl);
+      }
+      setResponseDownloadUrl("");
+      return;
+    }
+
+    const bytes = decodeBase64ToBytes(responsePayloadBase64);
+    if (!bytes) {
+      return;
+    }
+
+    const blobData = getBlobData(bytes);
+    const blob = new Blob([blobData], { type: responsePayloadMimeType });
+    const nextUrl = URL.createObjectURL(blob);
+
+    setResponseDownloadUrl((previousUrl) => {
+      if (previousUrl) {
+        URL.revokeObjectURL(previousUrl);
+      }
+      return nextUrl;
+    });
+
+    return () => {
+      URL.revokeObjectURL(nextUrl);
+    };
+  }, [responsePayloadBase64, responsePayloadMimeType]);
+
+  useEffect(() => {
+    if (responsePayloadMimeType !== "application/zip" || !responsePayloadBase64) {
+      setZipArchive(null);
+      setZipEntries([]);
+      setSelectedZipEntryName("");
+      return;
+    }
+
+    let isMounted = true;
+
+    async function loadZipArchive() {
+      const bytes = decodeBase64ToBytes(responsePayloadBase64);
+      if (!bytes) return;
+
+      const archive = await JSZip.loadAsync(getBlobData(bytes));
+      const entries = Object.values(archive.files)
+        .filter((entry) => !entry.dir)
+        .map((entry) => {
+          const mimeType = getMimeTypeFromPath(entry.name) || "application/octet-stream";
+          return {
+            name: entry.name,
+            mimeType,
+            previewType: getZipEntryPreviewType(mimeType),
+          };
+        })
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+      if (!isMounted) return;
+
+      setZipArchive(archive);
+      setZipEntries(entries);
+      setSelectedZipEntryName((current) =>
+        current && entries.some((entry) => entry.name === current)
+          ? current
+          : (entries[0]?.name ?? "")
+      );
+    }
+
+    loadZipArchive().catch((error) => {
+      console.error("Error parsing ZIP response:", error);
+      if (!isMounted) return;
+      setZipArchive(null);
+      setZipEntries([]);
+      setSelectedZipEntryName("");
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [responsePayloadBase64, responsePayloadMimeType]);
+
+  useEffect(() => {
+    setZipPreviewUrl((previousUrl) => {
+      if (previousUrl) {
+        URL.revokeObjectURL(previousUrl);
+      }
+      return "";
+    });
+
+    if (!zipArchive || !selectedZipEntryName) {
+      setZipPreviewText("");
+      setZipPreviewType("other");
+      return;
+    }
+
+    let isMounted = true;
+    const currentArchive = zipArchive;
+    setZipPreviewLoading(true);
+
+    async function loadZipEntryPreview() {
+      const entry = currentArchive.file(selectedZipEntryName);
+      const entryMeta = zipEntries.find((item) => item.name === selectedZipEntryName);
+      if (!entry || !entryMeta) {
+        if (!isMounted) return;
+        setZipPreviewType("other");
+        setZipPreviewText("");
+        setZipPreviewLoading(false);
+        return;
+      }
+
+      if (entryMeta.previewType === "text") {
+        const text = await entry.async("text");
+        if (!isMounted) return;
+
+        if (entryMeta.mimeType === "application/json") {
+          try {
+            setZipPreviewText(JSON.stringify(JSON.parse(text), null, 2));
+          } catch (_error) {
+            setZipPreviewText(text);
+          }
+        } else {
+          setZipPreviewText(text);
+        }
+
+        setZipPreviewType("text");
+        setZipPreviewLoading(false);
+        return;
+      }
+
+      if (entryMeta.previewType === "image" || entryMeta.previewType === "pdf") {
+        const bytes = await entry.async("uint8array");
+        if (!isMounted) return;
+
+        const url = URL.createObjectURL(
+          new Blob([getBlobData(bytes)], { type: entryMeta.mimeType })
+        );
+        setZipPreviewUrl(url);
+        setZipPreviewText("");
+        setZipPreviewType(entryMeta.previewType);
+        setZipPreviewLoading(false);
+        return;
+      }
+
+      if (!isMounted) return;
+      setZipPreviewType("other");
+      setZipPreviewText("");
+      setZipPreviewLoading(false);
+    }
+
+    loadZipEntryPreview().catch((error) => {
+      console.error("Error loading ZIP entry preview:", error);
+      if (!isMounted) return;
+      setZipPreviewType("other");
+      setZipPreviewText("");
+      setZipPreviewLoading(false);
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedZipEntryName, zipArchive, zipEntries]);
+
+  const handleDownloadResponse = () => {
+    if (!responseDownloadUrl) return;
+
+    const anchor = document.createElement("a");
+    anchor.href = responseDownloadUrl;
+    anchor.download = responseDownloadName || `${currentService?.name ?? "response"}.bin`;
+    anchor.click();
+  };
+
+  const handleDownloadZipEntry = async () => {
+    if (!zipArchive || !selectedZipEntryName) return;
+
+    const entry = zipArchive.file(selectedZipEntryName);
+    if (!entry) return;
+
+    const bytes = await entry.async("uint8array");
+    const mimeType =
+      zipEntries.find((item) => item.name === selectedZipEntryName)?.mimeType ||
+      "application/octet-stream";
+    const url = URL.createObjectURL(
+      new Blob([getBlobData(bytes)], { type: mimeType })
+    );
+
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = selectedZipEntryName.split("/").pop() || "download";
+    anchor.click();
+
+    URL.revokeObjectURL(url);
+  };
 
   const renderEditorView = () => (
     <div className="grid grid-cols-1 grid-rows-[auto_1fr] w-full gap-2">
@@ -290,7 +585,7 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
         <Select
           value={responseType}
           onValueChange={(value) =>
-            setResponseType(value as "text" | "image" | "file")
+            setResponseType(value as ResponseType)
           }
         >
           <SelectTrigger className="w-[100px]">
@@ -298,8 +593,17 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="text">Text</SelectItem>
-            <SelectItem value="image">Image</SelectItem>
-            <SelectItem value="file">File</SelectItem>
+            {responsePayloadMimeType.startsWith("image/") && (
+              <SelectItem value="image">Image</SelectItem>
+            )}
+            {responsePayloadMimeType === "application/zip" && (
+              <SelectItem value="zip">ZIP</SelectItem>
+            )}
+            {responsePayloadMimeType &&
+              responsePayloadMimeType !== "application/zip" &&
+              !responsePayloadMimeType.startsWith("image/") && (
+                <SelectItem value="file">File</SelectItem>
+              )}
           </SelectContent>
         </Select>
         <div className="h-full">
@@ -319,7 +623,7 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
           )}
           {responseType === "image" && (
             <img
-              src={`data:image/png;base64,${response.split("\n")[0]}`}
+              src={`data:${responsePayloadMimeType || "image/png"};base64,${responsePayloadBase64}`}
               alt="Response"
             />
           )}
@@ -333,6 +637,108 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
               }}
             >
               {responseFileContent}
+              {responseDownloadUrl && (
+                <div className="mt-4">
+                  <Button variant="outline" onClick={handleDownloadResponse}>
+                    <Download className="h-4 w-4 mr-2" />
+                    Download file
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+          {responseType === "zip" && (
+            <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-4 h-full min-h-0">
+              <div className="border rounded-md overflow-hidden min-h-[220px]">
+                <div className="flex items-center justify-between p-3 border-b bg-muted/50">
+                  <div>
+                    <p className="font-medium">ZIP contents</p>
+                    <p className="text-xs text-muted-foreground">
+                      {zipEntries.length} files
+                    </p>
+                  </div>
+                  {responseDownloadUrl && (
+                    <Button variant="outline" size="sm" onClick={handleDownloadResponse}>
+                      <Download className="h-4 w-4 mr-2" />
+                      ZIP
+                    </Button>
+                  )}
+                </div>
+                <div className="max-h-[50vh] overflow-auto">
+                  {zipEntries.map((entry) => (
+                    <button
+                      key={entry.name}
+                      type="button"
+                      className={`w-full text-left px-3 py-2 border-b hover:bg-muted/50 ${
+                        selectedZipEntryName === entry.name ? "bg-muted" : ""
+                      }`}
+                      onClick={() => setSelectedZipEntryName(entry.name)}
+                    >
+                      <div className="font-medium truncate">
+                        {entry.name.split("/").pop() || entry.name}
+                      </div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        {entry.name}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="border rounded-md min-h-[220px] overflow-hidden flex flex-col">
+                <div className="flex items-center justify-between p-3 border-b bg-muted/50">
+                  <div>
+                    <p className="font-medium">Preview</p>
+                    <p className="text-xs text-muted-foreground truncate">
+                      {selectedZipEntryName || "Select a file from the ZIP"}
+                    </p>
+                  </div>
+                  {selectedZipEntryName && (
+                    <Button variant="outline" size="sm" onClick={handleDownloadZipEntry}>
+                      <Download className="h-4 w-4 mr-2" />
+                      File
+                    </Button>
+                  )}
+                </div>
+                <div className="flex-1 min-h-0 overflow-auto p-3">
+                  {!selectedZipEntryName && (
+                    <div className="h-full flex items-center justify-center text-muted-foreground">
+                      Select a file to preview it before downloading.
+                    </div>
+                  )}
+                  {selectedZipEntryName && zipPreviewLoading && (
+                    <div className="h-full flex items-center justify-center text-muted-foreground">
+                      Loading preview...
+                    </div>
+                  )}
+                  {selectedZipEntryName && !zipPreviewLoading && zipPreviewType === "text" && (
+                    <pre className="whitespace-pre-wrap break-words text-sm">
+                      {zipPreviewText}
+                    </pre>
+                  )}
+                  {selectedZipEntryName && !zipPreviewLoading && zipPreviewType === "image" && zipPreviewUrl && (
+                    <div className="h-full flex items-center justify-center">
+                      <img
+                        src={zipPreviewUrl}
+                        alt={selectedZipEntryName}
+                        className="max-h-[52vh] w-auto rounded"
+                      />
+                    </div>
+                  )}
+                  {selectedZipEntryName && !zipPreviewLoading && zipPreviewType === "pdf" && zipPreviewUrl && (
+                    <iframe
+                      src={zipPreviewUrl}
+                      title={selectedZipEntryName}
+                      className="w-full h-[52vh] border-0"
+                    />
+                  )}
+                  {selectedZipEntryName && !zipPreviewLoading && zipPreviewType === "other" && (
+                    <div className="h-full flex items-center justify-center text-center text-muted-foreground px-6">
+                      Preview is not available for this file type. You can still
+                      download the selected file or the full ZIP.
+                    </div>
+                  )}
+                </div>
+              </div>
             </div>
           )}
         </div>
@@ -347,6 +753,23 @@ export function InvokePopover({ service, triggerRenderer }: Props) {
     setCurrentView("upload");
     setSelectedLanguage("plaintext");
     setResponse("");
+    setResponsePayloadBase64("");
+    setResponsePayloadMimeType("");
+    setResponseDownloadName("");
+    setZipArchive(null);
+    setZipEntries([]);
+    setSelectedZipEntryName("");
+    setZipPreviewType("other");
+    setZipPreviewText("");
+    setZipPreviewLoading(false);
+    if (zipPreviewUrl) {
+      URL.revokeObjectURL(zipPreviewUrl);
+    }
+    setZipPreviewUrl("");
+    if (responseDownloadUrl) {
+      URL.revokeObjectURL(responseDownloadUrl);
+    }
+    setResponseDownloadUrl("");
     setResponseType("text");
   };
 


### PR DESCRIPTION
## Summary

Enhance the service invoke dialog to better handle synchronous binary responses, especially ZIP payloads returned together with supervisor logs.

## Changes

- extract base64 payloads robustly from mixed log + payload responses
- avoid false positives by only treating recognized binary types as files
- detect ZIP responses and expose them explicitly in the UI
- preview ZIP contents before download
- allow downloading the full ZIP or an individual file inside it
- keep support for image and text previews where applicable

## Validation

- `npm run build`

## Notes

- local changes in `src/env.ts` were intentionally kept out of the branch push and are not part of this PR.

Fixes: https://github.com/grycap/issue-tracker/issues/344
