### PR TITLE
Improve quotas panel

### DIFF
--- a/src/api/quotas/getQuotaApi.ts
+++ b/src/api/quotas/getQuotaApi.ts
@@ -4,6 +4,10 @@ import { ClusterUserQuota } from "@/models/clusterUserQuota";
 import axios from "axios";
 
 function parseQuotaResources(data: ClusterUserQuota): ClusterUserQuota {
+  if (!data.resources) {
+    return data;
+  }
+
   const { cpu, memory } = data.resources;
   return {
     ...data,

--- a/src/api/volumes/getVolumesApi.ts
+++ b/src/api/volumes/getVolumesApi.ts
@@ -1,10 +1,9 @@
-import { Volumes } from "@/pages/ui/services/models/service";
+import { ManagedVolume } from "@/pages/ui/services/models/service";
 import axios from "axios";
 
-async function getVolumesApi() {
+async function getVolumesApi(): Promise<ManagedVolume[]> {
   const response = await axios.get("/system/volumes");
-  console.log("getVolumesApi response:", response.data);
-  return response.data as Volumes;
+  return response.data as ManagedVolume[];
 }
 
 export default getVolumesApi;

--- a/src/components/ResponsiveOwnerField/index.tsx
+++ b/src/components/ResponsiveOwnerField/index.tsx
@@ -5,26 +5,16 @@ import { Copy } from "lucide-react";
 
 export default function ResponsiveOwnerField({ owner, sub = owner, copy = true }: { owner: string, sub?: string, copy?: boolean }) {
   const {authData} = useAuth();
+  const isCurrentUser = sub === authData.egiSession?.sub || isUserOscar(authData, {owner: sub});
   return (
     <div
-      className={`grid grid-cols-[auto_1fr] no-underline ${copy && 'hover:underline'} underline-offset-2 cursor-pointer`}
+      className={`inline-grid max-w-full grid-cols-[minmax(0,auto)_auto] items-center gap-1 no-underline ${copy && 'hover:underline'} underline-offset-2 cursor-pointer`}
       onClick={() => { if (copy) { navigator.clipboard.writeText(sub ? sub : "oscar"); alert.success("Owner copied to clipboard"); } }}
     >
-    {sub !== authData.egiSession?.sub && !isUserOscar(authData, {owner: sub}) ?
-    <>
-      <span className="truncate min-w-[40px]">
-        {owner}
+      <span className="min-w-0 truncate">
+        {isCurrentUser ? "You" : owner}
       </span>
-      {copy && <Copy size={12} className="self-center ml-[2px]" />}
-    </>
-    :
-    <>
-      <span className="truncate min-w-[40px]">
-        {"You"}
-      </span>
-      {copy && <Copy size={12} className="self-center -ml-[14px]" />}
-      </>
-    }
+      {copy && <Copy size={12} className="shrink-0" />}
   </div>
   )
   

--- a/src/components/ResponsiveOwnerField/index.tsx
+++ b/src/components/ResponsiveOwnerField/index.tsx
@@ -8,7 +8,7 @@ export default function ResponsiveOwnerField({ owner, sub = owner, copy = true }
   const isCurrentUser = sub === authData.egiSession?.sub || isUserOscar(authData, {owner: sub});
   return (
     <div
-      className={`inline-grid max-w-full grid-cols-[minmax(0,auto)_auto] items-center gap-1 no-underline ${copy && 'hover:underline'} underline-offset-2 cursor-pointer`}
+      className={`grid grid-cols-[auto_1fr] items-center gap-1 no-underline ${copy && 'hover:underline'} underline-offset-2 cursor-pointer`}
       onClick={() => { if (copy) { navigator.clipboard.writeText(sub ? sub : "oscar"); alert.success("Owner copied to clipboard"); } }}
     >
       <span className="min-w-0 truncate">

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -41,6 +41,11 @@ function AppSidebar() {
 
   let items = [
     {
+      title: "Hub",
+      icon: <Boxes size={20} />,
+      path: "/hub",
+    },
+    {
       title: "Services",
       icon: <Codesandbox size={20} />,
       path: "/services",
@@ -72,11 +77,6 @@ function AppSidebar() {
       path: "/terminals",
     },
     {
-      title: "Hub",
-      icon: <Boxes size={20} />,
-      path: "/hub",
-    },
-    {
       title: "Status",
       icon: <BarChart2  size={20} />,
       path: "/status",
@@ -88,14 +88,14 @@ function AppSidebar() {
     },
   ];
 
-  // Only show quotas if the user is oscar
-  if (authContext.authData.user === "oscar") {
-    items = addItemToPosition(items, 
-      {
-        title: "Quotas",
-        icon: <ChartPie size={20} />,
-        path: "/quotas",
-      }, 6);
+  // Show quotas for the OSCAR admin and OIDC users with personal quota support.
+  if (authContext.authData.user === "oscar" || authContext.authData.egiSession) {
+    const statusIndex = items.findIndex((item) => item.path === "/status");
+    items = addItemToPosition(items, {
+      title: "Quotas",
+      icon: <ChartPie size={20} />,
+      path: "/quotas",
+    }, statusIndex + 1);
   }
   
   function buildLogoutRedirectUrl(token: string): string {

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/components/ui/sidebar";
 import { AnimatePresence, motion } from "framer-motion";
 import { Link, useLocation } from "react-router-dom";
-import { addItemToPosition, isVersionLower } from "@/lib/utils";
+import { isVersionLower } from "@/lib/utils";
 import env from "@/env";
 
 function AppSidebar() {
@@ -40,11 +40,6 @@ function AppSidebar() {
   const location = useLocation();
 
   let items = [
-    {
-      title: "Hub",
-      icon: <Boxes size={20} />,
-      path: "/hub",
-    },
     {
       title: "Services",
       icon: <Codesandbox size={20} />,
@@ -77,6 +72,16 @@ function AppSidebar() {
       path: "/terminals",
     },
     {
+      title: "Hub",
+      icon: <Boxes size={20} />,
+      path: "/hub",
+    },
+    {
+      title: "Quotas",
+      icon: <ChartPie size={20} />,
+      path: "/quotas",
+    },
+    {
       title: "Status",
       icon: <BarChart2  size={20} />,
       path: "/status",
@@ -87,16 +92,6 @@ function AppSidebar() {
       path: "/info",
     },
   ];
-
-  // Show quotas for the OSCAR admin and OIDC users with personal quota support.
-  if (authContext.authData.user === "oscar" || authContext.authData.egiSession) {
-    const statusIndex = items.findIndex((item) => item.path === "/status");
-    items = addItemToPosition(items, {
-      title: "Quotas",
-      icon: <ChartPie size={20} />,
-      path: "/quotas",
-    }, statusIndex + 1);
-  }
   
   function buildLogoutRedirectUrl(token: string): string {
     const tokenBody = JSON.parse(atob(token.split('.')[1]));

--- a/src/contexts/Volumes/VolumesContext.tsx
+++ b/src/contexts/Volumes/VolumesContext.tsx
@@ -54,7 +54,7 @@ export const VolumesProvider = ({
       setVolumesLoadingError(false);
       setVolumesAreLoading(true);
       const nextVolumes = await getVolumesApi();
-      setVolumes(nextVolumes.managed_volume ?? []);
+      setVolumes(nextVolumes);
     } catch (error) {
       console.error("Error fetching volumes:", error);
       alert.error(`Error fetching volumes: ${errorMessage(error)}`);

--- a/src/models/clusterUserQuota.ts
+++ b/src/models/clusterUserQuota.ts
@@ -1,20 +1,41 @@
 export type ClusterUserQuota = {
-    user_id?: string;
-    cluster_queue?: string;
-    resources: Resources;
+  user_id?: string;
+  cluster_queue?: string;
+  resources?: Resources;
+  volumes?: VolumeQuota;
 };
 
 type Resources = {
-    cpu: ResourceDetail;
-    memory: ResourceDetail;
+  cpu: ResourceDetail;
+  memory: ResourceDetail;
 };
 
 type ResourceDetail = {
-    max: number;
-    used: number;
-};  
+  max: number;
+  used: number;
+};
+
+export type VolumeQuota = {
+  disk: VolumeQuotaDetail;
+  volumes: VolumeQuotaDetail;
+  max_disk_per_volume: string;
+  min_disk_per_volume: string;
+};
+
+type VolumeQuotaDetail = {
+  max: string;
+  used: string;
+};
 
 export type QuotaUpdateRequest = {
-	cpu: string;
-	memory: string;
-}
+  cpu?: string;
+  memory?: string;
+  volumes?: VolumeQuotaUpdate;
+};
+
+type VolumeQuotaUpdate = {
+  disk?: string;
+  volumes?: string;
+  max_disk_per_volume?: string;
+  min_disk_per_volume?: string;
+};

--- a/src/pages/ui/cluster_info/index.tsx
+++ b/src/pages/ui/cluster_info/index.tsx
@@ -31,8 +31,6 @@ import { useLocation } from "react-router-dom";
 import getStatusApi from "@/api/status/getStatusApi";
 import { ClusterStatus } from "@/models/clusterStatus";
 import { useAuth } from "@/contexts/AuthContext";
-import { ClusterUserQuota } from "@/models/clusterUserQuota";
-import getUserQuotaApi from "@/api/quotas/getQuotaApi";
 import ExpandCard from "@/components/ExpandCard";
 import ClusterUseGraph from "./components/ClusterUseGraph";
 
@@ -87,7 +85,6 @@ const Cluster = () => {
 
   // access the authentication context
   const [clusterStatusData, setClusterStatusData] = useState<ClusterStatus | null>(null);
-  const [userQuotaData, setUserQuotaData] = useState<ClusterUserQuota | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -98,7 +95,6 @@ const Cluster = () => {
     try {
     setLoading(true);
     setClusterStatusData(await getStatusApi());
-    authData.egiSession && setUserQuotaData(await getUserQuotaApi());
     setLoading(false);
     } catch(err) {
       console.error("Error fetching status:", err);
@@ -141,91 +137,6 @@ const Cluster = () => {
       </div>
       :
       <div className="w-full max-w-full mx-auto px-4 pt-6 pb-6 space-y-6">
-        {/* User quota info block */}
-        {authData.user && authData.user !== "oscar" && userQuotaData && (
-        <Card className="w-full">
-          <CardHeader>
-            <CardTitle>User Quota</CardTitle>
-            <CardDescription className="text-sm text-gray-500">
-              Summary of your resource usage and quota limits.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="grid grid-cols-1 gap-4 items-stretch">
-            
-              {userQuotaData.resources && <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="grid grid-cols-1 gap-4">
-                  <div className="border rounded-lg p-4 shadow-sm">
-                    <div className="flex items-center gap-2">
-                      <Cpu className="text-black" size={24} />
-                      <p className="text-lg font-semibold">
-                        Max provided CPU:{" "}
-                        <span className={`text-xl font-bold`}>
-                           {formatCores(userQuotaData?.resources?.cpu.max ?? 0)}
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div className="border rounded-lg p-4 shadow-sm flex flex-col justify-start">
-                    <h2 className="text-lg font-semibold">{`CPU used ${formatCores(userQuotaData?.resources?.cpu.used ?? 0)}`}</h2>
-                    <div className="flex flex-col h-full justify-center">
-                      <DonutChart percentage={Math.round((userQuotaData?.resources?.cpu.used ?? 0) / (userQuotaData?.resources?.cpu.max ?? 1) * 100)} dangerThreshold={80} />
-                      <p className="text-center font-bold text-sm mt-2">
-                        {Number(((userQuotaData?.resources?.cpu.used ?? 0) / (userQuotaData?.resources?.cpu.max ?? 1) * 100).toFixed(1))}% Used
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div className="grid grid-cols-1 gap-4">
-                  <div className="border rounded-lg p-4 shadow-sm">
-                    <div className="flex items-center gap-2">
-                      <MemoryStick className="text-black" size={24} />
-                      <p className="text-lg font-semibold">
-                        Max provided memory:{" "}
-                        <span className={`text-xl font-bold`}>
-                           {formatBytes(userQuotaData?.resources?.memory.max ?? 0)}
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                  <div className="border rounded-lg p-4 shadow-sm flex flex-col justify-start">
-                    <h2 className="text-lg font-semibold">{`Memory used ${formatBytes(userQuotaData?.resources?.memory.used ?? 0)}`}</h2>
-                    <div className="flex flex-col h-full justify-center">
-                      <DonutChart percentage={Math.round((userQuotaData?.resources?.memory.used ?? 0) / (userQuotaData?.resources?.memory.max ?? 1) * 100)} dangerThreshold={80} />
-                      <p className="text-center font-bold text-sm mt-2">
-                        {Number(((userQuotaData?.resources?.memory.used ?? 0) / (userQuotaData?.resources?.memory.max ?? 1) * 100).toFixed(1))}% Used
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>}
-              {userQuotaData.volumes && <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="border rounded-lg p-4 shadow-sm">
-                  <div className="flex items-center gap-2">
-                    <Database className="text-black" size={24} />
-                    <p className="text-lg font-semibold">
-                      Volume disk used:{" "}
-                      <span className="text-xl font-bold">
-                        {userQuotaData.volumes.disk.used} / {userQuotaData.volumes.disk.max}
-                      </span>
-                    </p>
-                  </div>
-                </div>
-                <div className="border rounded-lg p-4 shadow-sm">
-                  <div className="flex items-center gap-2">
-                    <Files className="text-black" size={24} />
-                    <p className="text-lg font-semibold">
-                      Managed volumes used:{" "}
-                      <span className="text-xl font-bold">
-                        {userQuotaData.volumes.volumes.used} / {userQuotaData.volumes.volumes.max}
-                      </span>
-                    </p>
-                  </div>
-                </div>
-              </div>}
-          </CardContent>
-        </Card>
-        )}
-
         {/* Cluster general info block */}
         <Card className="w-full">
           <CardHeader>

--- a/src/pages/ui/cluster_info/index.tsx
+++ b/src/pages/ui/cluster_info/index.tsx
@@ -152,7 +152,7 @@ const Cluster = () => {
           </CardHeader>
           <CardContent className="grid grid-cols-1 gap-4 items-stretch">
             
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {userQuotaData.resources && <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="grid grid-cols-1 gap-4">
                   <div className="border rounded-lg p-4 shadow-sm">
                     <div className="flex items-center gap-2">
@@ -160,17 +160,17 @@ const Cluster = () => {
                       <p className="text-lg font-semibold">
                         Max provided CPU:{" "}
                         <span className={`text-xl font-bold`}>
-                           {formatCores(userQuotaData?.resources.cpu.max ?? 0)}
+                           {formatCores(userQuotaData?.resources?.cpu.max ?? 0)}
                         </span>
                       </p>
                     </div>
                   </div>
                   <div className="border rounded-lg p-4 shadow-sm flex flex-col justify-start">
-                    <h2 className="text-lg font-semibold">{`CPU used ${formatCores(userQuotaData?.resources.cpu.used ?? 0)}`}</h2>
+                    <h2 className="text-lg font-semibold">{`CPU used ${formatCores(userQuotaData?.resources?.cpu.used ?? 0)}`}</h2>
                     <div className="flex flex-col h-full justify-center">
-                      <DonutChart percentage={Math.round((userQuotaData?.resources.cpu.used ?? 0) / (userQuotaData?.resources.cpu.max ?? 1) * 100)} dangerThreshold={80} />
+                      <DonutChart percentage={Math.round((userQuotaData?.resources?.cpu.used ?? 0) / (userQuotaData?.resources?.cpu.max ?? 1) * 100)} dangerThreshold={80} />
                       <p className="text-center font-bold text-sm mt-2">
-                        {Number(((userQuotaData?.resources.cpu.used ?? 0) / (userQuotaData?.resources.cpu.max ?? 1) * 100).toFixed(1))}% Used
+                        {Number(((userQuotaData?.resources?.cpu.used ?? 0) / (userQuotaData?.resources?.cpu.max ?? 1) * 100).toFixed(1))}% Used
                       </p>
                     </div>
                   </div>
@@ -182,22 +182,46 @@ const Cluster = () => {
                       <p className="text-lg font-semibold">
                         Max provided memory:{" "}
                         <span className={`text-xl font-bold`}>
-                           {formatBytes(userQuotaData?.resources.memory.max ?? 0)}
+                           {formatBytes(userQuotaData?.resources?.memory.max ?? 0)}
                         </span>
                       </p>
                     </div>
                   </div>
                   <div className="border rounded-lg p-4 shadow-sm flex flex-col justify-start">
-                    <h2 className="text-lg font-semibold">{`Memory used ${formatBytes(userQuotaData?.resources.memory.used ?? 0)}`}</h2>
+                    <h2 className="text-lg font-semibold">{`Memory used ${formatBytes(userQuotaData?.resources?.memory.used ?? 0)}`}</h2>
                     <div className="flex flex-col h-full justify-center">
-                      <DonutChart percentage={Math.round((userQuotaData?.resources.memory.used ?? 0) / (userQuotaData?.resources.memory.max ?? 1) * 100)} dangerThreshold={80} />
+                      <DonutChart percentage={Math.round((userQuotaData?.resources?.memory.used ?? 0) / (userQuotaData?.resources?.memory.max ?? 1) * 100)} dangerThreshold={80} />
                       <p className="text-center font-bold text-sm mt-2">
-                        {Number(((userQuotaData?.resources.memory.used ?? 0) / (userQuotaData?.resources.memory.max ?? 1) * 100).toFixed(1))}% Used
+                        {Number(((userQuotaData?.resources?.memory.used ?? 0) / (userQuotaData?.resources?.memory.max ?? 1) * 100).toFixed(1))}% Used
                       </p>
                     </div>
                   </div>
                 </div>
-              </div>
+              </div>}
+              {userQuotaData.volumes && <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="border rounded-lg p-4 shadow-sm">
+                  <div className="flex items-center gap-2">
+                    <Database className="text-black" size={24} />
+                    <p className="text-lg font-semibold">
+                      Volume disk used:{" "}
+                      <span className="text-xl font-bold">
+                        {userQuotaData.volumes.disk.used} / {userQuotaData.volumes.disk.max}
+                      </span>
+                    </p>
+                  </div>
+                </div>
+                <div className="border rounded-lg p-4 shadow-sm">
+                  <div className="flex items-center gap-2">
+                    <Files className="text-black" size={24} />
+                    <p className="text-lg font-semibold">
+                      Managed volumes used:{" "}
+                      <span className="text-xl font-bold">
+                        {userQuotaData.volumes.volumes.used} / {userQuotaData.volumes.volumes.max}
+                      </span>
+                    </p>
+                  </div>
+                </div>
+              </div>}
           </CardContent>
         </Card>
         )}

--- a/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
+++ b/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
@@ -166,7 +166,7 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
       if (!serviceVolume) return;
 
       try {
-        const nextVolumes = (await getVolumesApi()).managed_volume;
+        const nextVolumes = await getVolumesApi();
         if (cancelled) return;
 
         const volumeExists = nextVolumes.some(

--- a/src/pages/ui/quotas/components/EditPopover/index.tsx
+++ b/src/pages/ui/quotas/components/EditPopover/index.tsx
@@ -7,7 +7,6 @@ import { Button } from "@/components/ui/button";
 import { alert } from "@/lib/alert";
 import putUserQuotaApi from "@/api/quotas/putQuotaApi";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { bytesSizeToHumanReadable } from "@/lib/utils";
 import { errorMessage } from "@/lib/error";
 
 const splitQuantity = (value?: string, fallbackUnit = "Gi") => {
@@ -18,13 +17,33 @@ const splitQuantity = (value?: string, fallbackUnit = "Gi") => {
   };
 };
 
+const bytesToEditableQuantity = (bytes?: number) => {
+  if (bytes === undefined || Number.isNaN(bytes)) {
+    return { value: "", unit: "Gi" };
+  }
+
+  const gib = bytes / 1024 ** 3;
+  if (gib >= 1 || bytes % 1024 ** 3 === 0) {
+    return { value: Number(gib.toFixed(2)).toString(), unit: "Gi" };
+  }
+
+  return { value: Number((bytes / 1024 ** 2).toFixed(2)).toString(), unit: "Mi" };
+};
+
+const isValidNumber = (value: string) => {
+  if (value.trim() === "") return false;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0;
+};
+
 interface EditPopoverProps {
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
   user: ClusterUserQuota;
+  onSaved?: () => Promise<void> | void;
 }
 
-function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
+function EditPopover({ isOpen, setIsOpen, user, onSaved }: EditPopoverProps) {
   const [formData, setFormData] = useState({
     uid: user.user_id ?? "",
     cpuMax: "",
@@ -38,6 +57,9 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
     minDiskPerVolume: "",
     minDiskPerVolumeUnit: "Mi",
   });
+
+  const [validationMessage, setValidationMessage] = useState("");
+  const [saving, setSaving] = useState(false);
 
   const [errors, setErrors] = useState({
     cpuMax: false,
@@ -55,7 +77,7 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
   useEffect(() => {
     if (!isOpen || !user) return;
 
-    const memory = bytesSizeToHumanReadable(user.resources?.memory.max ?? 0);
+    const memory = bytesToEditableQuantity(user.resources?.memory.max);
     const volumeDisk = splitQuantity(user.volumes?.disk.max);
     const maxDiskPerVolume = splitQuantity(user.volumes?.max_disk_per_volume);
     const minDiskPerVolume = splitQuantity(user.volumes?.min_disk_per_volume, "Mi");
@@ -63,8 +85,8 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
     setFormData({
       uid: user.user_id ?? "",
       cpuMax: user.resources ? (user.resources.cpu.max / 1000).toString() : "",
-      memoryMax: user.resources ? memory.replace(/([0-9.]+)\s*(\w+)/, "$1") : "",
-      memoryUnit: memory.replace(/([0-9.]+)\s*(\w+)/, "$2") === "GB" ? "Gi" : "Mi",
+      memoryMax: memory.value,
+      memoryUnit: memory.unit,
       volumeDiskMax: volumeDisk.value,
       volumeDiskUnit: volumeDisk.unit,
       volumesMax: user.volumes?.volumes.max ?? "",
@@ -85,25 +107,30 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
       minDiskPerVolume: false,
       minDiskPerVolumeUnit: false,
     });
+    setValidationMessage("");
   }, [isOpen, user]);
 
   const handleSave = async () => {
     const newErrors = {
-      cpuMax: Boolean(user.resources && !formData.cpuMax),
-      memoryMax: Boolean(user.resources && !formData.memoryMax),
+      cpuMax: Boolean(user.resources && !isValidNumber(formData.cpuMax)),
+      memoryMax: Boolean(user.resources && !isValidNumber(formData.memoryMax)),
       memoryUnit: Boolean(user.resources && !formData.memoryUnit),
-      volumeDiskMax: Boolean(user.volumes && !formData.volumeDiskMax),
+      volumeDiskMax: Boolean(user.volumes && !isValidNumber(formData.volumeDiskMax)),
       volumeDiskUnit: Boolean(user.volumes && !formData.volumeDiskUnit),
-      volumesMax: Boolean(user.volumes && !formData.volumesMax),
-      maxDiskPerVolume: Boolean(user.volumes && !formData.maxDiskPerVolume),
+      volumesMax: Boolean(user.volumes && !isValidNumber(formData.volumesMax)),
+      maxDiskPerVolume: Boolean(user.volumes && !isValidNumber(formData.maxDiskPerVolume)),
       maxDiskPerVolumeUnit: Boolean(user.volumes && !formData.maxDiskPerVolumeUnit),
-      minDiskPerVolume: Boolean(user.volumes && !formData.minDiskPerVolume),
+      minDiskPerVolume: Boolean(user.volumes && !isValidNumber(formData.minDiskPerVolume)),
       minDiskPerVolumeUnit: Boolean(user.volumes && !formData.minDiskPerVolumeUnit),
     };
 
     setErrors(newErrors);
 
-    if (Object.values(newErrors).some(Boolean)) return;
+    if (Object.values(newErrors).some(Boolean)) {
+      setValidationMessage("Review the highlighted fields before saving.");
+      return;
+    }
+    setValidationMessage("");
 
     const quotaUpdateRequest: QuotaUpdateRequest = {};
     if (user.resources) {
@@ -118,13 +145,16 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
         min_disk_per_volume: `${formData.minDiskPerVolume}${formData.minDiskPerVolumeUnit}`,
       };
     }
+    setSaving(true);
     try {
       await putUserQuotaApi(user.user_id!, quotaUpdateRequest);
+      await onSaved?.();
       alert.success(`Quota updated for user ${user.user_id}`);
       setIsOpen(false);
     } catch (error) {
-      console.log(error)
       alert.error(`Error updating quota for user ${user.user_id}: ${errorMessage(error)}`);
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -136,6 +166,12 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
         </DialogHeader>
 
         <div className="grid grid-cols-1 gap-3">
+          {validationMessage && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {validationMessage}
+            </div>
+          )}
+
           <div>
             <Label>UID</Label>
             <Input value={formData.uid} disabled />
@@ -143,15 +179,17 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
 
           {user.resources && <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pb-4">
             <div>
-              <Label>CPU Max</Label>
+              <Label>CPU Max (cores)</Label>
               <Input
                 type="number"
                 step={0.1}
+                min={0}
                 value={formData.cpuMax}
                 className={errors.cpuMax ? "border-red-500 focus:border-red-500" : ""}
                 onChange={(e) => {
                   setFormData({ ...formData, cpuMax: e.target.value });
                   if (errors.cpuMax) setErrors({ ...errors, cpuMax: false });
+                  if (validationMessage) setValidationMessage("");
                 }}
                 placeholder="Enter max CPU cores"
               />
@@ -161,11 +199,13 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
                 <Label>Max RAM</Label>
                 <Input
                   type="number"
+                  min={0}
                   value={formData.memoryMax}
                   className={errors.memoryMax ? "border-red-500 focus:border-red-500" : ""}
                   onChange={(e) => {
                     setFormData({ ...formData, memoryMax: e.target.value });
                     if (errors.memoryMax) setErrors({ ...errors, memoryMax: false });
+                    if (validationMessage) setValidationMessage("");
                   }}
                   placeholder="Enter max memory RAM"
                 />
@@ -180,8 +220,8 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
                   <SelectValue id="memory-unit" placeholder="Unit" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="Gi">GB</SelectItem>
-                  <SelectItem value="Mi">MB</SelectItem>
+                  <SelectItem value="Gi">GiB</SelectItem>
+                  <SelectItem value="Mi">MiB</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -193,13 +233,15 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
                 <Label>Volume Disk Max</Label>
                 <Input
                   type="number"
+                  min={0}
                   value={formData.volumeDiskMax}
                   className={errors.volumeDiskMax ? "border-red-500 focus:border-red-500" : ""}
                   onChange={(e) => {
                     setFormData({ ...formData, volumeDiskMax: e.target.value });
                     if (errors.volumeDiskMax) setErrors({ ...errors, volumeDiskMax: false });
+                    if (validationMessage) setValidationMessage("");
                   }}
-                  placeholder="Enter visible volume disk quota"
+                  placeholder="Enter max volume disk quota"
                 />
               </div>
               <Select
@@ -212,8 +254,8 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
                   <SelectValue id="volume-disk-unit" placeholder="Unit" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="Gi">GB</SelectItem>
-                  <SelectItem value="Mi">MB</SelectItem>
+                  <SelectItem value="Gi">GiB</SelectItem>
+                  <SelectItem value="Mi">MiB</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -222,11 +264,14 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
               <Label>Volumes Max</Label>
               <Input
                 type="number"
+                min={0}
+                step={1}
                 value={formData.volumesMax}
                 className={errors.volumesMax ? "border-red-500 focus:border-red-500" : ""}
                 onChange={(e) => {
                   setFormData({ ...formData, volumesMax: e.target.value });
                   if (errors.volumesMax) setErrors({ ...errors, volumesMax: false });
+                  if (validationMessage) setValidationMessage("");
                 }}
                 placeholder="Enter max number of managed volumes"
               />
@@ -238,11 +283,13 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
                   <Label>Max Disk Per Volume</Label>
                   <Input
                     type="number"
+                    min={0}
                     value={formData.maxDiskPerVolume}
                     className={errors.maxDiskPerVolume ? "border-red-500 focus:border-red-500" : ""}
                     onChange={(e) => {
                       setFormData({ ...formData, maxDiskPerVolume: e.target.value });
                       if (errors.maxDiskPerVolume) setErrors({ ...errors, maxDiskPerVolume: false });
+                      if (validationMessage) setValidationMessage("");
                     }}
                     placeholder="Enter max volume size"
                   />
@@ -257,8 +304,8 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
                     <SelectValue id="max-volume-disk-unit" placeholder="Unit" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="Gi">GB</SelectItem>
-                    <SelectItem value="Mi">MB</SelectItem>
+                    <SelectItem value="Gi">GiB</SelectItem>
+                    <SelectItem value="Mi">MiB</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -268,11 +315,13 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
                   <Label>Min Disk Per Volume</Label>
                   <Input
                     type="number"
+                    min={0}
                     value={formData.minDiskPerVolume}
                     className={errors.minDiskPerVolume ? "border-red-500 focus:border-red-500" : ""}
                     onChange={(e) => {
                       setFormData({ ...formData, minDiskPerVolume: e.target.value });
                       if (errors.minDiskPerVolume) setErrors({ ...errors, minDiskPerVolume: false });
+                      if (validationMessage) setValidationMessage("");
                     }}
                     placeholder="Enter min volume size"
                   />
@@ -287,8 +336,8 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
                     <SelectValue id="min-volume-disk-unit" placeholder="Unit" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="Gi">GB</SelectItem>
-                    <SelectItem value="Mi">MB</SelectItem>
+                    <SelectItem value="Gi">GiB</SelectItem>
+                    <SelectItem value="Mi">MiB</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -301,7 +350,9 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
             <Button variant="ghost" onClick={() => setIsOpen(false)}>
               Cancel
             </Button>
-            <Button onClick={handleSave}>Save</Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? "Saving" : "Save changes"}
+            </Button>
           </div>
         </DialogFooter>
       </DialogContent>

--- a/src/pages/ui/quotas/components/EditPopover/index.tsx
+++ b/src/pages/ui/quotas/components/EditPopover/index.tsx
@@ -10,6 +10,14 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { bytesSizeToHumanReadable } from "@/lib/utils";
 import { errorMessage } from "@/lib/error";
 
+const splitQuantity = (value?: string, fallbackUnit = "Gi") => {
+  const match = value?.match(/^([0-9.]+)\s*([A-Za-z]+)$/);
+  return {
+    value: match?.[1] ?? "",
+    unit: match?.[2] ?? fallbackUnit,
+  };
+};
+
 interface EditPopoverProps {
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
@@ -21,55 +29,95 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
     uid: user.user_id ?? "",
     cpuMax: "",
     memoryMax: "",
-    memoryUnit: "Gi"
+    memoryUnit: "Gi",
+    volumeDiskMax: "",
+    volumeDiskUnit: "Gi",
+    volumesMax: "",
+    maxDiskPerVolume: "",
+    maxDiskPerVolumeUnit: "Gi",
+    minDiskPerVolume: "",
+    minDiskPerVolumeUnit: "Mi",
   });
 
   const [errors, setErrors] = useState({
     cpuMax: false,
     memoryMax: false,
-    memoryUnit: false
+    memoryUnit: false,
+    volumeDiskMax: false,
+    volumeDiskUnit: false,
+    volumesMax: false,
+    maxDiskPerVolume: false,
+    maxDiskPerVolumeUnit: false,
+    minDiskPerVolume: false,
+    minDiskPerVolumeUnit: false,
   });
 
   useEffect(() => {
     if (!isOpen || !user) return;
 
+    const memory = bytesSizeToHumanReadable(user.resources?.memory.max ?? 0);
+    const volumeDisk = splitQuantity(user.volumes?.disk.max);
+    const maxDiskPerVolume = splitQuantity(user.volumes?.max_disk_per_volume);
+    const minDiskPerVolume = splitQuantity(user.volumes?.min_disk_per_volume, "Mi");
+
     setFormData({
       uid: user.user_id ?? "",
-      cpuMax: (user.resources.cpu.max / 1000).toString(), // Convert millicores to cores
-      memoryMax: bytesSizeToHumanReadable(user.resources.memory.max ?? 0).replace(/([0-9.]+)\s*(\w+)/, '$1'), // Extract the numeric part
-      memoryUnit: bytesSizeToHumanReadable(user.resources.memory.max ?? 0).replace(/([0-9.]+)\s*(\w+)/, '$2') === "GB" ? "Gi" : "Mi" // Extract the unit part
+      cpuMax: user.resources ? (user.resources.cpu.max / 1000).toString() : "",
+      memoryMax: user.resources ? memory.replace(/([0-9.]+)\s*(\w+)/, "$1") : "",
+      memoryUnit: memory.replace(/([0-9.]+)\s*(\w+)/, "$2") === "GB" ? "Gi" : "Mi",
+      volumeDiskMax: volumeDisk.value,
+      volumeDiskUnit: volumeDisk.unit,
+      volumesMax: user.volumes?.volumes.max ?? "",
+      maxDiskPerVolume: maxDiskPerVolume.value,
+      maxDiskPerVolumeUnit: maxDiskPerVolume.unit,
+      minDiskPerVolume: minDiskPerVolume.value,
+      minDiskPerVolumeUnit: minDiskPerVolume.unit,
     });
     setErrors({
       cpuMax: false,
       memoryMax: false,
-      memoryUnit: false
+      memoryUnit: false,
+      volumeDiskMax: false,
+      volumeDiskUnit: false,
+      volumesMax: false,
+      maxDiskPerVolume: false,
+      maxDiskPerVolumeUnit: false,
+      minDiskPerVolume: false,
+      minDiskPerVolumeUnit: false,
     });
   }, [isOpen, user]);
 
   const handleSave = async () => {
     const newErrors = {
-      cpuMax: !formData.cpuMax,
-      memoryMax: !formData.memoryMax,
-      memoryUnit: !formData.memoryUnit
+      cpuMax: Boolean(user.resources && !formData.cpuMax),
+      memoryMax: Boolean(user.resources && !formData.memoryMax),
+      memoryUnit: Boolean(user.resources && !formData.memoryUnit),
+      volumeDiskMax: Boolean(user.volumes && !formData.volumeDiskMax),
+      volumeDiskUnit: Boolean(user.volumes && !formData.volumeDiskUnit),
+      volumesMax: Boolean(user.volumes && !formData.volumesMax),
+      maxDiskPerVolume: Boolean(user.volumes && !formData.maxDiskPerVolume),
+      maxDiskPerVolumeUnit: Boolean(user.volumes && !formData.maxDiskPerVolumeUnit),
+      minDiskPerVolume: Boolean(user.volumes && !formData.minDiskPerVolume),
+      minDiskPerVolumeUnit: Boolean(user.volumes && !formData.minDiskPerVolumeUnit),
     };
 
     setErrors(newErrors);
 
     if (Object.values(newErrors).some(Boolean)) return;
 
-    const cpuMax = Number(formData.cpuMax).toPrecision(3); // Convert cores to millicores
-    const memoryMax = `${formData.memoryMax}${formData.memoryUnit}`;
-    
-    console.log("Saving quota with values:", {
-      uid: formData.uid,
-      cpuMax,
-      memoryMax
-    });
-    const quotaUpdateRequest: QuotaUpdateRequest = {
-      cpu: cpuMax,
-      memory: memoryMax
-    };
-
+    const quotaUpdateRequest: QuotaUpdateRequest = {};
+    if (user.resources) {
+      quotaUpdateRequest.cpu = Number(formData.cpuMax).toString();
+      quotaUpdateRequest.memory = `${formData.memoryMax}${formData.memoryUnit}`;
+    }
+    if (user.volumes) {
+      quotaUpdateRequest.volumes = {
+        disk: `${formData.volumeDiskMax}${formData.volumeDiskUnit}`,
+        volumes: formData.volumesMax,
+        max_disk_per_volume: `${formData.maxDiskPerVolume}${formData.maxDiskPerVolumeUnit}`,
+        min_disk_per_volume: `${formData.minDiskPerVolume}${formData.minDiskPerVolumeUnit}`,
+      };
+    }
     try {
       await putUserQuotaApi(user.user_id!, quotaUpdateRequest);
       alert.success(`Quota updated for user ${user.user_id}`);
@@ -82,7 +130,7 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DialogContent className="max-w-[500px] max-h-[90%] gap-4 flex flex-col">
+      <DialogContent className="max-w-[720px] max-h-[90%] gap-4 flex flex-col overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Edit user quota</DialogTitle>
         </DialogHeader>
@@ -93,7 +141,7 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
             <Input value={formData.uid} disabled />
           </div>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pb-4">
+          {user.resources && <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pb-4">
             <div>
               <Label>CPU Max</Label>
               <Input
@@ -137,7 +185,115 @@ function EditPopover({ isOpen, setIsOpen, user }: EditPopoverProps) {
                 </SelectContent>
               </Select>
             </div>
-          </div>
+          </div>}
+
+          {user.volumes && <div className="grid grid-cols-1 gap-3 pb-4">
+            <div className="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-2 items-end">
+              <div>
+                <Label>Volume Disk Max</Label>
+                <Input
+                  type="number"
+                  value={formData.volumeDiskMax}
+                  className={errors.volumeDiskMax ? "border-red-500 focus:border-red-500" : ""}
+                  onChange={(e) => {
+                    setFormData({ ...formData, volumeDiskMax: e.target.value });
+                    if (errors.volumeDiskMax) setErrors({ ...errors, volumeDiskMax: false });
+                  }}
+                  placeholder="Enter visible volume disk quota"
+                />
+              </div>
+              <Select
+                value={formData.volumeDiskUnit}
+                onValueChange={(value) =>
+                  setFormData({ ...formData, volumeDiskUnit: value })
+                }
+              >
+                <SelectTrigger className="w-[80px]">
+                  <SelectValue id="volume-disk-unit" placeholder="Unit" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Gi">GB</SelectItem>
+                  <SelectItem value="Mi">MB</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div>
+              <Label>Volumes Max</Label>
+              <Input
+                type="number"
+                value={formData.volumesMax}
+                className={errors.volumesMax ? "border-red-500 focus:border-red-500" : ""}
+                onChange={(e) => {
+                  setFormData({ ...formData, volumesMax: e.target.value });
+                  if (errors.volumesMax) setErrors({ ...errors, volumesMax: false });
+                }}
+                placeholder="Enter max number of managed volumes"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="grid grid-cols-[1fr_auto] gap-2 items-end">
+                <div>
+                  <Label>Max Disk Per Volume</Label>
+                  <Input
+                    type="number"
+                    value={formData.maxDiskPerVolume}
+                    className={errors.maxDiskPerVolume ? "border-red-500 focus:border-red-500" : ""}
+                    onChange={(e) => {
+                      setFormData({ ...formData, maxDiskPerVolume: e.target.value });
+                      if (errors.maxDiskPerVolume) setErrors({ ...errors, maxDiskPerVolume: false });
+                    }}
+                    placeholder="Enter max volume size"
+                  />
+                </div>
+                <Select
+                  value={formData.maxDiskPerVolumeUnit}
+                  onValueChange={(value) =>
+                    setFormData({ ...formData, maxDiskPerVolumeUnit: value })
+                  }
+                >
+                  <SelectTrigger className="w-[80px]">
+                    <SelectValue id="max-volume-disk-unit" placeholder="Unit" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Gi">GB</SelectItem>
+                    <SelectItem value="Mi">MB</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="grid grid-cols-[1fr_auto] gap-2 items-end">
+                <div>
+                  <Label>Min Disk Per Volume</Label>
+                  <Input
+                    type="number"
+                    value={formData.minDiskPerVolume}
+                    className={errors.minDiskPerVolume ? "border-red-500 focus:border-red-500" : ""}
+                    onChange={(e) => {
+                      setFormData({ ...formData, minDiskPerVolume: e.target.value });
+                      if (errors.minDiskPerVolume) setErrors({ ...errors, minDiskPerVolume: false });
+                    }}
+                    placeholder="Enter min volume size"
+                  />
+                </div>
+                <Select
+                  value={formData.minDiskPerVolumeUnit}
+                  onValueChange={(value) =>
+                    setFormData({ ...formData, minDiskPerVolumeUnit: value })
+                  }
+                >
+                  <SelectTrigger className="w-[80px]">
+                    <SelectValue id="min-volume-disk-unit" placeholder="Unit" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Gi">GB</SelectItem>
+                    <SelectItem value="Mi">MB</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </div>}
         </div>
 
         <DialogFooter>

--- a/src/pages/ui/quotas/components/QuotaEmptyState/index.tsx
+++ b/src/pages/ui/quotas/components/QuotaEmptyState/index.tsx
@@ -1,0 +1,31 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Search } from "lucide-react";
+
+type QuotaEmptyStateProps = {
+  hasSearched: boolean;
+  adminMode: boolean;
+};
+
+function QuotaEmptyState({ hasSearched, adminMode }: QuotaEmptyStateProps) {
+  return (
+    <Card className="border-dashed">
+      <CardContent className="flex min-h-[280px] items-center justify-center px-4 py-8">
+        <div className="max-w-[520px] text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-700 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-200">
+            <Search size={22} />
+          </div>
+          <h2 className="text-lg font-semibold text-slate-950 dark:text-slate-50">
+            {hasSearched ? "No quota loaded" : adminMode ? "Load a user quota" : "Your quota will appear here"}
+          </h2>
+          <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+            {adminMode
+              ? "Enter the exact user ID and load the current quota from /system/quotas/user."
+              : "Use refresh to load your current quota from /system/quotas/user."}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default QuotaEmptyState;

--- a/src/pages/ui/quotas/components/QuotaLoadingState/index.tsx
+++ b/src/pages/ui/quotas/components/QuotaLoadingState/index.tsx
@@ -1,0 +1,34 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function QuotaLoadingState() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <CardHeader className="p-4 pb-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-7 w-full max-w-[360px]" />
+        </CardHeader>
+        <CardContent className="flex justify-end gap-2 p-4 pt-2">
+          <Skeleton className="h-10 w-28" />
+          <Skeleton className="h-10 w-28" />
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Card key={index}>
+            <CardContent className="p-4">
+              <Skeleton className="h-5 w-32" />
+              <Skeleton className="mt-3 h-7 w-24" />
+              <Skeleton className="mt-2 h-4 w-28" />
+              <Skeleton className="mt-3 h-2 w-full" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default QuotaLoadingState;

--- a/src/pages/ui/quotas/components/QuotaMetricCard/index.tsx
+++ b/src/pages/ui/quotas/components/QuotaMetricCard/index.tsx
@@ -1,0 +1,44 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { ReactNode } from "react";
+
+type QuotaMetricCardProps = {
+  icon: ReactNode;
+  label: string;
+  max: string;
+  used?: string;
+  percentage?: number;
+};
+
+function QuotaMetricCard({ icon, label, max, used, percentage }: QuotaMetricCardProps) {
+  return (
+    <Card className="h-full">
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2 text-sm font-medium text-slate-600 dark:text-slate-300">
+            <span className="text-slate-900 dark:text-slate-50">{icon}</span>
+            <span className="truncate">{label}</span>
+          </div>
+          {percentage !== undefined && (
+            <Badge variant={percentage >= 80 ? "destructive" : "secondary"}>{percentage}% used</Badge>
+          )}
+        </div>
+
+        <div className="mt-3 text-xl font-semibold text-slate-950 dark:text-slate-50">{max}</div>
+        {used !== undefined && (
+          <div className="mt-1 text-sm text-slate-500 dark:text-slate-400">Used: {used}</div>
+        )}
+        {percentage !== undefined && (
+          <div className="mt-3 h-2 rounded-full bg-slate-100 dark:bg-slate-800">
+            <div
+              className={`h-2 rounded-full ${percentage >= 80 ? "bg-red-500" : "bg-[#009688]"}`}
+              style={{ width: `${percentage}%` }}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default QuotaMetricCard;

--- a/src/pages/ui/quotas/components/QuotaSummary/index.tsx
+++ b/src/pages/ui/quotas/components/QuotaSummary/index.tsx
@@ -1,0 +1,109 @@
+import ResponsiveOwnerField from "@/components/ResponsiveOwnerField";
+import { Button } from "@/components/ui/button";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ClusterUserQuota } from "@/models/clusterUserQuota";
+import { Cpu, HardDrive, Layers, MemoryStick, Pencil } from "lucide-react";
+import QuotaMetricCard from "../QuotaMetricCard";
+import {
+  formatBytes,
+  formatCores,
+  formatQuota,
+  usagePercentage,
+  usagePercentageFromCount,
+  usagePercentageFromQuantity,
+} from "../../utils/quotaFormatters";
+
+type QuotaSummaryProps = {
+  quota: ClusterUserQuota;
+  userId: string;
+  adminMode: boolean;
+  onEdit: () => void;
+};
+
+function QuotaSummary({ quota, userId, adminMode, onEdit }: QuotaSummaryProps) {
+  const cpuUsed = quota.resources?.cpu.used;
+  const cpuMax = quota.resources?.cpu.max;
+  const memoryUsed = quota.resources?.memory.used;
+  const memoryMax = quota.resources?.memory.max;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <CardHeader className="grid gap-4 p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+          <div className="min-w-0">
+            <CardDescription>{adminMode ? "User quota" : "My quota"}</CardDescription>
+            <CardTitle className="mt-1 text-xl">
+              <ResponsiveOwnerField owner={userId} copy />
+            </CardTitle>
+            {adminMode && quota.cluster_queue && (
+              <CardDescription className="mt-2">
+                ClusterQueue: <span className="font-medium text-slate-700 dark:text-slate-200">{quota.cluster_queue}</span>
+              </CardDescription>
+            )}
+          </div>
+
+          {adminMode && (
+            <div className="flex flex-wrap gap-2 md:justify-end">
+              <Button onClick={onEdit}>
+                <Pencil size={16} className="mr-2" />
+                Edit quota
+              </Button>
+            </div>
+          )}
+        </CardHeader>
+      </Card>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {quota.resources && (
+          <>
+            <QuotaMetricCard
+              icon={<Cpu size={18} />}
+              label="CPU limit"
+              max={`${formatCores(cpuMax)} cores`}
+              used={`${formatCores(cpuUsed)} cores`}
+              percentage={usagePercentage(cpuUsed, cpuMax)}
+            />
+            <QuotaMetricCard
+              icon={<MemoryStick size={18} />}
+              label="Memory limit"
+              max={formatBytes(memoryMax)}
+              used={formatBytes(memoryUsed)}
+              percentage={usagePercentage(memoryUsed, memoryMax)}
+            />
+          </>
+        )}
+
+        {quota.volumes && (
+          <>
+            <QuotaMetricCard
+              icon={<HardDrive size={18} />}
+              label="Volume disk limit"
+              max={formatQuota(quota.volumes.disk.max)}
+              used={formatQuota(quota.volumes.disk.used)}
+              percentage={usagePercentageFromQuantity(quota.volumes.disk.used, quota.volumes.disk.max)}
+            />
+            <QuotaMetricCard
+              icon={<Layers size={18} />}
+              label="Managed volumes limit"
+              max={formatQuota(quota.volumes.volumes.max)}
+              used={formatQuota(quota.volumes.volumes.used)}
+              percentage={usagePercentageFromCount(quota.volumes.volumes.used, quota.volumes.volumes.max)}
+            />
+            <QuotaMetricCard
+              icon={<HardDrive size={18} />}
+              label="Max disk per volume"
+              max={formatQuota(quota.volumes.max_disk_per_volume)}
+            />
+            <QuotaMetricCard
+              icon={<HardDrive size={18} />}
+              label="Min disk per volume"
+              max={formatQuota(quota.volumes.min_disk_per_volume)}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default QuotaSummary;

--- a/src/pages/ui/quotas/index.tsx
+++ b/src/pages/ui/quotas/index.tsx
@@ -1,152 +1,155 @@
 import getUserQuotaApi from "@/api/quotas/getQuotaApi";
-import GenericTable from "@/components/Table";
 import GenericTopbar from "@/components/Topbar";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { bytesSizeToHumanReadable } from "@/lib/utils";
+import { useAuth } from "@/contexts/AuthContext";
+import { errorMessage } from "@/lib/error";
 import { ClusterUserQuota } from "@/models/clusterUserQuota";
-import { Pencil, Search } from "lucide-react";
+import { Search } from "lucide-react";
 import { useState } from "react";
 import EditPopover from "./components/EditPopover";
-import ResponsiveOwnerField from "@/components/ResponsiveOwnerField";
-import { errorMessage } from "@/lib/error";
+import QuotaEmptyState from "./components/QuotaEmptyState";
+import QuotaLoadingState from "./components/QuotaLoadingState";
+import QuotaSummary from "./components/QuotaSummary";
 
-type QuotaRow = {
-  uid: string;
-  cpuUsed?: number;
-  cpuMax?: number;
-  memoryUsed?: number;
-  memoryMax?: number;
-  volumeDiskUsed?: string;
-  volumeDiskMax?: string;
-  volumesUsed?: string;
-  volumesMax?: string;
+type LoadQuotaOptions = {
+  userId?: string;
+  preserveExisting?: boolean;
 };
 
-const formatCores = (millicores?: number) =>
-  millicores === undefined ? "-" : (millicores / 1000).toString();
-
-const formatBytes = (bytes?: number) =>
-  bytes === undefined ? "-" : bytesSizeToHumanReadable(bytes);
-
-const formatQuota = (value?: string) => value || "-";
-
 function Quotas() {
-  const [users, setUsers] = useState(Array<ClusterUserQuota>());
+  const { authData } = useAuth();
+  const adminMode = authData.user === "oscar";
+  const personalMode = Boolean(authData.egiSession) && !adminMode;
+  const [quota, setQuota] = useState<ClusterUserQuota | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const [lastLoadedUid, setLastLoadedUid] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [inputError, setInputError] = useState("");
+  const [hasSearched, setHasSearched] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
-  const [selectedUser, setSelectedUser] = useState<ClusterUserQuota>();
 
-  async function searchUsersByUID(uid: string) {
+  async function loadQuota({ userId, preserveExisting = false }: LoadQuotaOptions = {}) {
+    const normalizedUserId = userId?.trim();
+    setInputError("");
+    setError("");
+
+    if (adminMode && !normalizedUserId) {
+      setInputError("Enter a user ID before loading quota.");
+      return;
+    }
+
+    setLoading(true);
+    setHasSearched(true);
     try {
-      const quota = await getUserQuotaApi(uid);
-      setUsers([quota]);
-    } catch (error) {
-      console.error(`Error fetching user quota: ${errorMessage(error)}`);
-      setUsers([]);
+      const loadedQuota = await getUserQuotaApi(adminMode ? normalizedUserId : undefined);
+      const loadedUserId = loadedQuota.user_id || normalizedUserId || authData.egiSession?.sub || "";
+      setQuota(loadedQuota);
+      setLastLoadedUid(loadedUserId);
+      if (adminMode) {
+        setSearchQuery(loadedUserId);
+      }
+    } catch (loadError) {
+      if (!preserveExisting) {
+        setQuota(null);
+        setLastLoadedUid("");
+      }
+      setError(errorMessage(loadError));
+    } finally {
+      setLoading(false);
     }
   }
 
+  const refreshQuota = async () => {
+    await loadQuota({
+      userId: adminMode ? lastLoadedUid : undefined,
+      preserveExisting: true,
+    });
+  };
+
+  const topbarActions = adminMode ? (
+    <div className="grid w-full gap-2 px-3 py-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+      <Input
+        placeholder="User ID"
+        value={searchQuery}
+        onChange={(event) => {
+          setSearchQuery(event.target.value);
+          if (inputError) setInputError("");
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") loadQuota({ userId: searchQuery });
+        }}
+        endIcon={<Search size={16} />}
+        aria-invalid={Boolean(inputError)}
+      />
+      <Button onClick={() => loadQuota({ userId: searchQuery })} disabled={loading}>
+        <Search size={16} className="mr-2" />
+        {loading ? "Loading" : "Load quota"}
+      </Button>
+    </div>
+  ) : undefined;
+
+  const topbarRefresher = personalMode || (adminMode && lastLoadedUid) ? refreshQuota : undefined;
+  const userId = quota?.user_id || lastLoadedUid;
+
   return (
-    <div className="w-full h-full overflow-auto">
-      <GenericTopbar defaultHeader={{title: "Quotas", linkTo: "/ui/quotas"}} 
-        secondaryRow={
-          <div className="grid grid-cols-[1fr_auto] w-full px-2 py-1 gap-2">
-            <Input
-              placeholder="Search services by UID"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              endIcon={<Search size={16} />}
-            />
-            <Button onClick={() => searchUsersByUID(searchQuery)}>Search</Button>
-          </div>
-        }
+    <div className="h-full w-full overflow-auto">
+      <GenericTopbar
+        defaultHeader={{ title: "Quotas", linkTo: "/ui/quotas" }}
+        refresher={topbarRefresher}
+        secondaryRow={topbarActions}
       />
 
-      <GenericTable
-        data={users.map((user) => ({
-            uid: user.user_id ?? "",
-            cpuUsed: user.resources?.cpu.used,
-            cpuMax: user.resources?.cpu.max,
-            memoryUsed: user.resources?.memory.used,
-            memoryMax: user.resources?.memory.max,
-            volumeDiskUsed: user.volumes?.disk.used,
-            volumeDiskMax: user.volumes?.disk.max,
-            volumesUsed: user.volumes?.volumes.used,
-            volumesMax: user.volumes?.volumes.max,
-            })
-          ) as QuotaRow[]
-        }
-        idKey={"uid"}
-        columns={
-          [
-            {
-              header: "UID",
-              accessor: (row) => <ResponsiveOwnerField owner={row.uid} copy={true} />,
-              sortBy: "uid",
-            },
-            {
-              header: "CPU Used",
-              accessor: (row) => formatCores(row.cpuUsed),
-              sortBy: "cpuUsed",
-            },
-            {
-              header: "CPU Max",
-              accessor: (row) => formatCores(row.cpuMax),
-              sortBy: "cpuMax",
-            },
-            {
-              header: "Memory Used",
-              accessor: (row) => formatBytes(row.memoryUsed),
-              sortBy: "memoryUsed",
-            },
-            {
-              header: "Memory Max",
-              accessor: (row) => formatBytes(row.memoryMax),
-              sortBy: "memoryMax",
-            },
-            {
-              header: "Volume Disk Used",
-              accessor: (row) => formatQuota(row.volumeDiskUsed),
-              sortBy: "volumeDiskUsed",
-            },
-            {
-              header: "Volume Disk Max",
-              accessor: (row) => formatQuota(row.volumeDiskMax),
-              sortBy: "volumeDiskMax",
-            },
-            {
-              header: "Volumes Used",
-              accessor: (row) => formatQuota(row.volumesUsed),
-              sortBy: "volumesUsed",
-            },
-            {
-              header: "Volumes Max",
-              accessor: (row) => formatQuota(row.volumesMax),
-              sortBy: "volumesMax",
-            },
-          ]
-        }
-        actions={[
-          {
-            button: (item) => (
-              <>
-              <Button variant={"link"} size="icon" tooltipLabel="Edit" onClick={() => {
-                setSelectedUser(users.find((u) => u.user_id === item.uid));
-                setIsEditOpen(true);
-              }}>
-                <Pencil />
-              </Button>
-              
-              </>
-            )
-          },
-        ]}
-      />
-      {selectedUser && <EditPopover isOpen={isEditOpen} setIsOpen={setIsEditOpen} user={selectedUser} />}
+      <div className="w-full max-w-full mx-auto px-4 pt-6 pb-6 space-y-6">
+        {!adminMode && !personalMode && (
+          <Alert variant="destructive">
+            <AlertTitle>Quotas unavailable</AlertTitle>
+            <AlertDescription>
+              Personal quota lookup is available for OIDC users. Admin quota management is available for oscar.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {inputError && (
+          <Alert variant="destructive">
+            <AlertTitle>Missing user ID</AlertTitle>
+            <AlertDescription>{inputError}</AlertDescription>
+          </Alert>
+        )}
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertTitle>Quota could not be loaded</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {loading && !quota ? (
+          <QuotaLoadingState />
+        ) : quota ? (
+          <QuotaSummary
+            quota={quota}
+            userId={userId}
+            adminMode={adminMode}
+            onEdit={() => setIsEditOpen(true)}
+          />
+        ) : (
+          <QuotaEmptyState hasSearched={hasSearched} adminMode={adminMode} />
+        )}
+      </div>
+
+      {adminMode && quota && (
+        <EditPopover
+          isOpen={isEditOpen}
+          setIsOpen={setIsEditOpen}
+          user={quota}
+          onSaved={refreshQuota}
+        />
+      )}
     </div>
   );
-  
 }
 
 export default Quotas;

--- a/src/pages/ui/quotas/index.tsx
+++ b/src/pages/ui/quotas/index.tsx
@@ -11,6 +11,25 @@ import EditPopover from "./components/EditPopover";
 import ResponsiveOwnerField from "@/components/ResponsiveOwnerField";
 import { errorMessage } from "@/lib/error";
 
+type QuotaRow = {
+  uid: string;
+  cpuUsed?: number;
+  cpuMax?: number;
+  memoryUsed?: number;
+  memoryMax?: number;
+  volumeDiskUsed?: string;
+  volumeDiskMax?: string;
+  volumesUsed?: string;
+  volumesMax?: string;
+};
+
+const formatCores = (millicores?: number) =>
+  millicores === undefined ? "-" : (millicores / 1000).toString();
+
+const formatBytes = (bytes?: number) =>
+  bytes === undefined ? "-" : bytesSizeToHumanReadable(bytes);
+
+const formatQuota = (value?: string) => value || "-";
 
 function Quotas() {
   const [users, setUsers] = useState(Array<ClusterUserQuota>());
@@ -46,13 +65,17 @@ function Quotas() {
 
       <GenericTable
         data={users.map((user) => ({
-            uid: user.user_id!,
-            cpuUsed: user.resources.cpu.used,
-            cpuMax: user.resources.cpu.max,
-            memoryUsed: user.resources.memory.used,
-            memoryMax: user.resources.memory.max,
+            uid: user.user_id ?? "",
+            cpuUsed: user.resources?.cpu.used,
+            cpuMax: user.resources?.cpu.max,
+            memoryUsed: user.resources?.memory.used,
+            memoryMax: user.resources?.memory.max,
+            volumeDiskUsed: user.volumes?.disk.used,
+            volumeDiskMax: user.volumes?.disk.max,
+            volumesUsed: user.volumes?.volumes.used,
+            volumesMax: user.volumes?.volumes.max,
             })
-          )
+          ) as QuotaRow[]
         }
         idKey={"uid"}
         columns={
@@ -64,23 +87,43 @@ function Quotas() {
             },
             {
               header: "CPU Used",
-              accessor: (row) => (row.cpuUsed / 1000).toString(),
+              accessor: (row) => formatCores(row.cpuUsed),
               sortBy: "cpuUsed",
             },
             {
               header: "CPU Max",
-              accessor: (row) => (row.cpuMax / 1000).toString(),
+              accessor: (row) => formatCores(row.cpuMax),
               sortBy: "cpuMax",
             },
             {
               header: "Memory Used",
-              accessor: (row) => bytesSizeToHumanReadable(row.memoryUsed),
+              accessor: (row) => formatBytes(row.memoryUsed),
               sortBy: "memoryUsed",
             },
             {
               header: "Memory Max",
-              accessor: (row) => bytesSizeToHumanReadable(row.memoryMax),
+              accessor: (row) => formatBytes(row.memoryMax),
               sortBy: "memoryMax",
+            },
+            {
+              header: "Volume Disk Used",
+              accessor: (row) => formatQuota(row.volumeDiskUsed),
+              sortBy: "volumeDiskUsed",
+            },
+            {
+              header: "Volume Disk Max",
+              accessor: (row) => formatQuota(row.volumeDiskMax),
+              sortBy: "volumeDiskMax",
+            },
+            {
+              header: "Volumes Used",
+              accessor: (row) => formatQuota(row.volumesUsed),
+              sortBy: "volumesUsed",
+            },
+            {
+              header: "Volumes Max",
+              accessor: (row) => formatQuota(row.volumesMax),
+              sortBy: "volumesMax",
             },
           ]
         }

--- a/src/pages/ui/quotas/utils/quotaFormatters.ts
+++ b/src/pages/ui/quotas/utils/quotaFormatters.ts
@@ -1,0 +1,38 @@
+import { bytesSizeToHumanReadable, parseMemoryToBytes } from "@/lib/utils";
+
+export const formatCores = (millicores?: number) =>
+  millicores === undefined ? "-" : (millicores / 1000).toString();
+
+export const formatBytes = (bytes?: number) =>
+  bytes === undefined ? "-" : bytesSizeToHumanReadable(bytes);
+
+export const formatQuota = (value?: string) => value || "-";
+
+export const usagePercentage = (used?: number, max?: number) => {
+  if (used === undefined || max === undefined || max <= 0) return undefined;
+  return Math.min(Math.round((used / max) * 100), 100);
+};
+
+export const usagePercentageFromQuantity = (used?: string, max?: string) => {
+  if (!used || !max) return undefined;
+
+  const parsedUsed = parseMemoryToBytes(used);
+  const parsedMax = parseMemoryToBytes(max);
+  if (!Number.isFinite(parsedUsed) || !Number.isFinite(parsedMax)) {
+    return undefined;
+  }
+
+  return usagePercentage(parsedUsed, parsedMax);
+};
+
+export const usagePercentageFromCount = (used?: string, max?: string) => {
+  if (!used || !max) return undefined;
+
+  const parsedUsed = Number(used);
+  const parsedMax = Number(max);
+  if (!Number.isFinite(parsedUsed) || !Number.isFinite(parsedMax)) {
+    return undefined;
+  }
+
+  return usagePercentage(parsedUsed, parsedMax);
+};

--- a/src/pages/ui/services/models/service.ts
+++ b/src/pages/ui/services/models/service.ts
@@ -136,11 +136,6 @@ export enum Bucket_visibility {
   public = "public",
 }
 
-export interface Volumes {
-  volume_limits: VolumeLimits;
-  managed_volume: ManagedVolume[];
-}
-
 export interface VolumeStatus {
   phase?: string;
   message?: string;
@@ -150,13 +145,6 @@ export interface VolumeStatus {
 export interface VolumeAttachmentReference {
   service_name: string;
   mount_path: string;
-}
-
-export interface VolumeLimits {
-  disk_available: number;
-  max_volumes: string;
-  max_disk_per_volume: string;
-  min_disk_per_volume: string;
 }
 
 export interface ManagedVolume {

--- a/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
+++ b/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
@@ -148,7 +148,7 @@ function TerminalFormPopover() {
           return;
         }
 
-        setVolumes(nextVolumes.managed_volume ?? []);
+        setVolumes(nextVolumes);
       } catch (error) {
         if (cancelled) {
           return;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -18,7 +18,6 @@ import TerminalView from "@/pages/ui/terminals";
 import Cluster from "@/pages/ui/cluster_info"
 import HubView from "@/pages/ui/hub";
 import Quotas from "@/pages/ui/quotas";
-import AdminRoute from "@/components/AdminRoute/AdminRoute";
 import UploadFromPresignedURL from "@/pages/UploadFromPresignedURL";
 
 function AppRouter() {
@@ -48,12 +47,7 @@ function AppRouter() {
           <Route path="terminals" element={<TerminalView />} />
           <Route path="status" element={<Cluster />} />
           <Route path="hub" element={<HubView />} />
-          <Route path="quotas" element={
-            <AdminRoute>
-              <Quotas />
-            </AdminRoute>
-            }
-          />
+          <Route path="quotas" element={<Quotas />} />
           
           
         </Route>


### PR DESCRIPTION
## Summary

- Reworks the Quotas page into a shared panel for the OSCAR admin and OIDC users.
- Keeps admin quota lookup/editing through the existing `/system/quotas/user/{userId}` endpoint.
- Adds a read-only personal quota view for OIDC users through `/system/quotas/user`.
- Moves user quota information out of Status and keeps Status focused on cluster health.
- Aligns the Quotas UI with the dashboard card/topbar patterns, including consistent refresh behavior and progress indicators for CPU, memory, volume disk, and managed volumes.
- Moves Hub to the first sidebar position and places Quotas after Status.

This branch is based on the head of #120, so it also contains the volume quota contract changes from that PR.

## Validation

- `npm run build`
- `npx eslint` on the touched files

## Notes

`src/env.ts` had local uncommitted changes before this work and was intentionally left out of the commit.