### PR TITLE
Fix exposed service liveness fallback

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -88,7 +88,7 @@ export async function exposedServiceIsAlive(url: string, delay = 6000, attempts 
       });
       if (response.ok) {
         return true;
-      } else if (response.status === 405) {
+      } else if (response.status !== 503) {
         const response = await fetch(url, { 
           method: 'GET',
           mode: 'cors',


### PR DESCRIPTION
## Summary

- Update exposed service liveness checks to try `GET` after receiving non-503 error response

## Why

Some exposed applications, including FileBrowser Quantum, are reachable in the browser with `GET` but do not return a clean successful `HEAD` response. The dashboard kept showing the spinner even though the service was usable.

## Validation

- `npm run build`