### PR TITLE
Adds FileBrowser support as an integrated Dashboard application.

### DIFF
--- a/src/components/IntegratedApp/index.tsx
+++ b/src/components/IntegratedApp/index.tsx
@@ -23,6 +23,8 @@ interface IntegratedAppProps {
     filteredServices: Service[];
     DeployInstancePopover: React.ComponentType;
     additionalExposedPathArgs?: string;
+    authActionPathArgs?: string;
+    targetExposedPath?: string;
     healthcheckPath?: string;
 }
 
@@ -31,6 +33,8 @@ function IntegratedApp({
   deployedServiceEndpoint,
   filteredServices,
   additionalExposedPathArgs,
+  authActionPathArgs,
+  targetExposedPath,
   healthcheckPath,
   DeployInstancePopover,
 }: IntegratedAppProps) {
@@ -183,6 +187,8 @@ function IntegratedApp({
                   service={service}
                   endpoint={deployedServiceEndpoint}
                   additionalExposedPathArgs={additionalExposedPathArgs}
+                  authActionPathArgs={authActionPathArgs}
+                  targetExposedPath={targetExposedPath}
                   healthcheckPath={healthcheckPath}
                 />
               </div>

--- a/src/components/ServiceRedirectButton/index.tsx
+++ b/src/components/ServiceRedirectButton/index.tsx
@@ -92,7 +92,7 @@ function ServiceRedirectButton({
 
     const token = await signJwt(
       {
-        sub: service.environment.variables.FILEBROWSER_JWT_SUB ?? "admin",
+        sub: service.environment.variables.FILEBROWSER_JWT_SUB ?? "oscar-dashboard",
         groups: ["admin"],
       },
       secret,

--- a/src/components/ServiceRedirectButton/index.tsx
+++ b/src/components/ServiceRedirectButton/index.tsx
@@ -97,7 +97,7 @@ function ServiceRedirectButton({
 
     const token = await signJwt(
       {
-        sub: service.environment.variables.FILEBROWSER_JWT_SUB ?? "oscar-dashboard",
+        sub: service.environment.variables.FILEBROWSER_JWT_SUB ?? "user",
         groups: ["admin"],
       },
       secret,

--- a/src/components/ServiceRedirectButton/index.tsx
+++ b/src/components/ServiceRedirectButton/index.tsx
@@ -2,7 +2,6 @@ import { ExternalLink, Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { exposedServiceIsAlive, isVersionLower } from "@/lib/utils";
 import { Service } from "@/pages/ui/services/models/service";
-import { Link } from "react-router-dom";
 import OscarColors from "@/styles";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -12,20 +11,26 @@ function ServiceRedirectButton({
   service,
   endpoint,
   additionalExposedPathArgs,
+  authActionPathArgs,
+  targetExposedPath,
   healthcheckPath = "",
 }: {
   className?: string;
   service: Service;
   endpoint: string;
   additionalExposedPathArgs?: string;
+  authActionPathArgs?: string;
+  targetExposedPath?: string;
   healthcheckPath?: string;
 }) {
   const [isAlive, setIsAlive] = useState<boolean | null>(null);
   const [redirectLink, setRedirectLink] = useState<string>("");
+  const [authActionLink, setAuthActionLink] = useState<string>("");
   const { clusterInfo } = useAuth();
 
   const safeHealthcheckPath = healthcheckPath.startsWith("/") ? healthcheckPath.slice(1).trim() : healthcheckPath
   const healthcheckLink = `${endpoint}/system/services/${service.name}/exposed/${safeHealthcheckPath}`;
+  const exposedBaseLink = `${endpoint}/system/services/${service.name}/exposed/`;
       
   /**
    * Interpolate variables in the additionalExposedPathArgs string.
@@ -147,6 +152,65 @@ function ServiceRedirectButton({
       .replace(/=+$/g, "");
   }
 
+  function buildExposedUrl(pathArgs?: string) {
+    if (!pathArgs) {
+      return exposedBaseLink;
+    }
+
+    const safePathArgs = pathArgs.startsWith("/")
+      ? pathArgs.slice(1)
+      : pathArgs;
+
+    return `${exposedBaseLink}${safePathArgs}`;
+  }
+
+  function submitAuthFormAndRedirect() {
+    const targetName = `oscar-filebrowser-${Date.now()}`;
+    const popup = window.open("about:blank", targetName);
+
+    if (!popup) {
+      return;
+    }
+
+    popup.document.write("<!doctype html><title>Opening FileBrowser</title><p>Opening FileBrowser...</p>");
+    const form = document.createElement("form");
+    form.method = "POST";
+    form.action = authActionLink;
+    form.target = targetName;
+    form.style.display = "none";
+    document.body.appendChild(form);
+    form.submit();
+    document.body.removeChild(form);
+
+    window.setTimeout(() => {
+      popup.location.href = redirectLink;
+    }, 800);
+  }
+
+  async function handleRedirectClick() {
+    if (!authActionLink) {
+      window.open(redirectLink, "_blank", "noopener,noreferrer");
+      return;
+    }
+
+    try {
+      const response = await fetch(authActionLink, {
+        method: "POST",
+        mode: "cors",
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        throw new Error(`Authentication request failed with status ${response.status}`);
+      }
+
+      window.open(redirectLink, "_blank", "noopener,noreferrer");
+    } catch (error) {
+      console.warn("Falling back to form-based service authentication", error);
+      submitAuthFormAndRedirect();
+    }
+  }
+
   useEffect(() => {
     let isMounted = true;
 
@@ -155,10 +219,15 @@ function ServiceRedirectButton({
         service,
         additionalExposedPathArgs
       );
+      const interpolatedAuthActionArgs = await interpolateVariables(
+        service,
+        authActionPathArgs
+      );
 
       if (isMounted) {
-        setRedirectLink(
-          `${endpoint}/system/services/${service.name}/exposed/${interpolatedArgs}`
+        setRedirectLink(buildExposedUrl(targetExposedPath ?? interpolatedArgs));
+        setAuthActionLink(
+          interpolatedAuthActionArgs ? buildExposedUrl(interpolatedAuthActionArgs) : ""
         );
       }
     };
@@ -184,16 +253,17 @@ function ServiceRedirectButton({
     return () => {
       isMounted = false;
     };
-  }, [service, endpoint, additionalExposedPathArgs, healthcheckPath]);
+  }, [service, endpoint, additionalExposedPathArgs, authActionPathArgs, targetExposedPath, healthcheckPath]);
 
   return isAlive && redirectLink ? (
-    <Link
+    <button
+      type="button"
       className={`${className ?? ""}`}
-      to={redirectLink}
-      target="_blank"
+      onClick={handleRedirectClick}
+      style={{ background: "none", border: 0, cursor: "pointer", padding: 0 }}
     >
       <ExternalLink />
-    </Link>
+    </button>
   ) : (
     <Loader2 className={`animate-spin ${className ?? ""}`} color={OscarColors.DarkGrayText} />
   );

--- a/src/components/ServiceRedirectButton/index.tsx
+++ b/src/components/ServiceRedirectButton/index.tsx
@@ -4,6 +4,7 @@ import { exposedServiceIsAlive, isVersionLower } from "@/lib/utils";
 import { Service } from "@/pages/ui/services/models/service";
 import OscarColors from "@/styles";
 import { useAuth } from "@/contexts/AuthContext";
+import getDeploymentStatusApi from "@/api/deployment/getDeploymentStatusApi";
 
 
 function ServiceRedirectButton({
@@ -237,6 +238,22 @@ function ServiceRedirectButton({
         if (isMounted) setIsAlive(true);
         return;
       }
+
+      if (service.deployment?.state === "ready") {
+        if (isMounted) setIsAlive(true);
+        return;
+      }
+
+      try {
+        const deploymentStatus = await getDeploymentStatusApi(service.name);
+        if (deploymentStatus.state === "ready") {
+          if (isMounted) setIsAlive(true);
+          return;
+        }
+      } catch (error) {
+        console.warn(`Deployment status check failed for ${service.name}:`, error);
+      }
+
       try {
         const status = await exposedServiceIsAlive(healthcheckLink, 10000, 20);
         if (isMounted) { 

--- a/src/components/ServiceRedirectButton/index.tsx
+++ b/src/components/ServiceRedirectButton/index.tsx
@@ -21,8 +21,8 @@ function ServiceRedirectButton({
   healthcheckPath?: string;
 }) {
   const [isAlive, setIsAlive] = useState<boolean | null>(null);
+  const [redirectLink, setRedirectLink] = useState<string>("");
   const { clusterInfo } = useAuth();
-  const redirectLink = `${endpoint}/system/services/${service.name}/exposed/${interpolateVariables(service, additionalExposedPathArgs)}`
 
   const safeHealthcheckPath = healthcheckPath.startsWith("/") ? healthcheckPath.slice(1).trim() : healthcheckPath
   const healthcheckLink = `${endpoint}/system/services/${service.name}/exposed/${safeHealthcheckPath}`;
@@ -30,30 +30,139 @@ function ServiceRedirectButton({
   /**
    * Interpolate variables in the additionalExposedPathArgs string.
    * This function replaces variables in the format {{ variableName }} with their corresponding values from the
-   * service's environment variables or service properties. It supports variables prefixed with "env." for environment variables and "service."
-   * example: evn.MY_VAR or service.token
+   * service's environment variables, service properties, or short-lived JWTs.
+   * Examples: env.MY_VAR, service.token, jwt.service.token
    */
-  function interpolateVariables(service: Service, additionalExposedPathArgs?: string) {
+  async function interpolateVariables(service: Service, additionalExposedPathArgs?: string) {
     if (!additionalExposedPathArgs) return "";
 
-    return additionalExposedPathArgs.replace(/{{\s*([^}]+)\s*}}/g, (_, variableName) => {
+    const matches = [...additionalExposedPathArgs.matchAll(/{{\s*([^}]+)\s*}}/g)];
+    let interpolatedValue = additionalExposedPathArgs;
+
+    for (const match of matches) {
+      const placeholder = match[0];
+      const variableName = match[1];
       const splitVariable = variableName.split(".");
       const prefix = splitVariable[0];
       const variableKey = splitVariable[1];
+      let resolvedValue = "";
+
       switch (prefix) {
         case "env":
-          return service.environment.variables[variableKey] ?? "";
+          resolvedValue = service.environment.variables[variableKey] ?? "";
+          break;
         case "service":
           const serviceValue = (service[variableKey as keyof Service]);
-          return typeof serviceValue === "string" ? serviceValue : "";
+          resolvedValue = typeof serviceValue === "string" ? serviceValue : "";
+          break;
+        case "jwt":
+          resolvedValue = await generateJwtPlaceholder(service, splitVariable);
+          break;
         default:
-          return "";
+          resolvedValue = "";
       }
+
+      interpolatedValue = interpolatedValue.replace(placeholder, resolvedValue);
+    }
+
+    return interpolatedValue;
+  }
+
+  function resolveStringValue(service: Service, source: string, key: string) {
+    if (source === "env") {
+      return service.environment.variables[key] ?? "";
+    }
+
+    if (source === "service") {
+      const serviceValue = service[key as keyof Service];
+      return typeof serviceValue === "string" ? serviceValue : "";
+    }
+
+    return "";
+  }
+
+  async function generateJwtPlaceholder(service: Service, splitVariable: string[]) {
+    const secretSource = splitVariable[1];
+    const secretKey = splitVariable[2];
+    const secret = resolveStringValue(service, secretSource, secretKey);
+
+    if (!secret) {
+      return "";
+    }
+
+    const token = await signJwt(
+      {
+        sub: service.environment.variables.FILEBROWSER_JWT_SUB ?? "admin",
+        groups: ["admin"],
+      },
+      secret,
+      3600
+    );
+
+    return encodeURIComponent(token);
+  }
+
+  async function signJwt(
+    payload: Record<string, unknown>,
+    secret: string,
+    ttlSeconds: number
+  ) {
+    const now = Math.floor(Date.now() / 1000);
+    const encoder = new TextEncoder();
+    const header = base64UrlEncode(encoder.encode(JSON.stringify({
+      alg: "HS256",
+      typ: "JWT",
+    })));
+    const body = base64UrlEncode(encoder.encode(JSON.stringify({
+      ...payload,
+      iat: now,
+      exp: now + ttlSeconds,
+    })));
+    const unsignedToken = `${header}.${body}`;
+    const cryptoKey = await crypto.subtle.importKey(
+      "raw",
+      encoder.encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    );
+    const signature = await crypto.subtle.sign(
+      "HMAC",
+      cryptoKey,
+      encoder.encode(unsignedToken)
+    );
+
+    return `${unsignedToken}.${base64UrlEncode(new Uint8Array(signature))}`;
+  }
+
+  function base64UrlEncode(bytes: Uint8Array) {
+    let binary = "";
+    bytes.forEach((byte) => {
+      binary += String.fromCharCode(byte);
     });
+
+    return btoa(binary)
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/g, "");
   }
 
   useEffect(() => {
     let isMounted = true;
+
+    const buildRedirectLink = async () => {
+      const interpolatedArgs = await interpolateVariables(
+        service,
+        additionalExposedPathArgs
+      );
+
+      if (isMounted) {
+        setRedirectLink(
+          `${endpoint}/system/services/${service.name}/exposed/${interpolatedArgs}`
+        );
+      }
+    };
+
     const checkStatus = async () => {
       if (clusterInfo && isVersionLower(clusterInfo.version, "3.6.4")) {
         if (isMounted) setIsAlive(true);
@@ -70,13 +179,14 @@ function ServiceRedirectButton({
         }
       }
     };
+    buildRedirectLink();
     checkStatus();
     return () => {
       isMounted = false;
     };
-  }, [service.name, endpoint, healthcheckPath]);
+  }, [service, endpoint, additionalExposedPathArgs, healthcheckPath]);
 
-  return isAlive ? (
+  return isAlive && redirectLink ? (
     <Link
       className={`${className ?? ""}`}
       to={redirectLink}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -5,6 +5,7 @@ import {
   ChartPie,
   Codesandbox,
   Database,
+  FolderOpen,
   HardDrive,
   Info,
   LogOut,
@@ -70,6 +71,11 @@ function AppSidebar() {
       title: "Terminals",
       icon: <Terminal size={20} />,
       path: "/terminals",
+    },
+    {
+      title: "File Browsers",
+      icon: <FolderOpen size={20} />,
+      path: "/filebrowsers",
     },
     {
       title: "Hub",

--- a/src/components/SimpleServiceRedirectButton/index.tsx
+++ b/src/components/SimpleServiceRedirectButton/index.tsx
@@ -1,0 +1,92 @@
+import { ExternalLink, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { exposedServiceIsAlive, isVersionLower } from "@/lib/utils";
+import { Service } from "@/pages/ui/services/models/service";
+import { Link } from "react-router-dom";
+import OscarColors from "@/styles";
+import { useAuth } from "@/contexts/AuthContext";
+
+
+function SimpleServiceRedirectButton({
+  className,
+  service,
+  endpoint,
+  additionalExposedPathArgs,
+  healthcheckPath = "",
+}: {
+  className?: string;
+  service: Service;
+  endpoint: string;
+  additionalExposedPathArgs?: string;
+  healthcheckPath?: string;
+}) {
+  const [isAlive, setIsAlive] = useState<boolean | null>(null);
+  const { clusterInfo } = useAuth();
+  const redirectLink = `${endpoint}/system/services/${service.name}/exposed/${interpolateVariables(service, additionalExposedPathArgs)}`
+
+  const safeHealthcheckPath = healthcheckPath.startsWith("/") ? healthcheckPath.slice(1).trim() : healthcheckPath
+  const healthcheckLink = `${endpoint}/system/services/${service.name}/exposed/${safeHealthcheckPath}`;
+      
+  /**
+   * Interpolate variables in the additionalExposedPathArgs string.
+   * This function replaces variables in the format {{ variableName }} with their corresponding values from the
+   * service's environment variables or service properties. It supports variables prefixed with "env." for environment variables and "service."
+   * example: evn.MY_VAR or service.token
+   */
+  function interpolateVariables(service: Service, additionalExposedPathArgs?: string) {
+    if (!additionalExposedPathArgs) return "";
+
+    return additionalExposedPathArgs.replace(/{{\s*([^}]+)\s*}}/g, (_, variableName) => {
+      const splitVariable = variableName.split(".");
+      const prefix = splitVariable[0];
+      const variableKey = splitVariable[1];
+      switch (prefix) {
+        case "env":
+          return service.environment.variables[variableKey] ?? "";
+        case "service":
+          const serviceValue = (service[variableKey as keyof Service]);
+          return typeof serviceValue === "string" ? serviceValue : "";
+        default:
+          return "";
+      }
+    });
+  }
+
+  useEffect(() => {
+    let isMounted = true;
+    const checkStatus = async () => {
+      if (clusterInfo && isVersionLower(clusterInfo.version, "3.6.4")) {
+        if (isMounted) setIsAlive(true);
+        return;
+      }
+      try {
+        const status = await exposedServiceIsAlive(healthcheckLink, 10000, 20);
+        if (isMounted) { 
+          setIsAlive(status);
+        }
+      } catch (error) {
+        if (isMounted) {
+          setIsAlive(false);
+        }
+      }
+    };
+    checkStatus();
+    return () => {
+      isMounted = false;
+    };
+  }, [service.name, endpoint, healthcheckPath]);
+
+  return isAlive ? (
+    <Link
+      className={`${className ?? ""}`}
+      to={redirectLink}
+      target="_blank"
+    >
+      <ExternalLink />
+    </Link>
+  ) : (
+    <Loader2 className={`animate-spin ${className ?? ""}`} color={OscarColors.DarkGrayText} />
+  );
+}
+
+export default SimpleServiceRedirectButton;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -81,25 +81,29 @@ export function generateReadableName(length = 6) {
 export async function exposedServiceIsAlive(url: string, delay = 6000, attempts = -1): Promise<boolean> {
   for (let i = 0; i < attempts || attempts === -1; i++) {
     try {
-      const response = await fetch(url, { 
+      const headResponse = await fetch(url, { 
         method: 'HEAD',
         mode: 'cors',
         credentials: 'omit'
       });
-      if (response.ok) {
+      if (headResponse.ok) {
         return true;
-      } else if (response.status === 405) {
-        const response = await fetch(url, { 
-          method: 'GET',
-          mode: 'cors',
-          credentials: 'omit'
-        });
-        if (response.ok) {
-          return true;
-        }
       }
     } catch (error) {
-      console.error(`Attempt ${i + 1} failed:`, error);
+      console.warn(`HEAD health check attempt ${i + 1} failed:`, error);
+    }
+
+    try {
+      const getResponse = await fetch(url, { 
+        method: 'GET',
+        mode: 'cors',
+        credentials: 'omit'
+      });
+      if (getResponse.ok) {
+        return true;
+      }
+    } catch (error) {
+      console.error(`GET health check attempt ${i + 1} failed:`, error);
     }
     await sleep(delay);
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -80,40 +80,26 @@ export function generateReadableName(length = 6) {
 
 export async function exposedServiceIsAlive(url: string, delay = 6000, attempts = -1): Promise<boolean> {
   for (let i = 0; i < attempts || attempts === -1; i++) {
-    let shouldTryGet = true;
-
     try {
-      const headResponse = await fetch(url, { 
+      const response = await fetch(url, { 
         method: 'HEAD',
         mode: 'cors',
         credentials: 'omit'
       });
-      if (headResponse.ok) {
+      if (response.ok) {
         return true;
-      }
-
-      shouldTryGet = headResponse.status !== 503;
-      if (!shouldTryGet) {
-        await sleep(delay);
-        continue;
-      }
-    } catch (error) {
-      console.warn(`HEAD health check attempt ${i + 1} failed:`, error);
-    }
-
-    if (shouldTryGet) {
-      try {
-        const getResponse = await fetch(url, {
+      } else if (response.status !== 503) {
+        const response = await fetch(url, { 
           method: 'GET',
           mode: 'cors',
           credentials: 'omit'
         });
-        if (getResponse.ok) {
+        if (response.ok) {
           return true;
         }
-      } catch (error) {
-        console.error(`GET health check attempt ${i + 1} failed:`, error);
       }
+    } catch (error) {
+      console.error(`Attempt ${i + 1} failed:`, error);
     }
     await sleep(delay);
   }

--- a/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
+++ b/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
@@ -1,0 +1,486 @@
+import createServiceApi from "@/api/services/createServiceApi";
+import getVolumesApi from "@/api/volumes/getVolumesApi";
+import RequestButton from "@/components/RequestButton";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useAuth } from "@/contexts/AuthContext";
+import useGetPrivateBuckets from "@/hooks/useGetPrivateBuckets";
+import { alert } from "@/lib/alert";
+import { errorMessage } from "@/lib/error";
+import {
+  fetchFromGitHubOptions,
+  generateReadableName,
+  genRandomString,
+  getAllowedVOs,
+  isVersionLower,
+} from "@/lib/utils";
+import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
+import useServicesContext from "@/pages/ui/services/context/ServicesContext";
+import { ManagedVolume, Service } from "@/pages/ui/services/models/service";
+import OscarColors from "@/styles";
+import { Plus, RefreshCcwIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+
+const FILEBROWSER_FDL_URL =
+  "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/feat-add-filebrowser/crates/filebrowser-quantum/fdl.yml";
+const FILEBROWSER_SCRIPT_URL =
+  "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/feat-add-filebrowser/crates/filebrowser-quantum/script.sh";
+
+type StorageMode = "volume" | "bucket";
+
+function FileBrowserFormPopover() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [newBucket, setNewBucket] = useState(false);
+  const [volumes, setVolumes] = useState<ManagedVolume[]>([]);
+  const { systemConfig, authData, clusterInfo } = useAuth();
+  const { refreshServices } = useServicesContext();
+  const buckets = useGetPrivateBuckets();
+  const oidcGroups = getAllowedVOs(systemConfig, authData);
+  const volumeSupportEnabled =
+    clusterInfo && !isVersionLower(clusterInfo.version, "v3.8.0");
+
+  function nameService() {
+    return (
+      `filebrowser-${generateReadableName(6)}-` +
+      `${genRandomString(8).toLowerCase()}`
+    );
+  }
+
+  const [formData, setFormData] = useState({
+    name: "",
+    cpuCores: "0.5",
+    memoryRam: "512",
+    memoryUnit: "Mi",
+    storageMode: "volume" as StorageMode,
+    bucket: "",
+    volume: "",
+    vo: "",
+    token: "",
+  });
+
+  const [errors, setErrors] = useState({
+    name: false,
+    cpuCores: false,
+    memoryRam: false,
+    storage: false,
+    vo: false,
+  });
+
+  useEffect(() => {
+    if (oidcGroups.length > 0 && !formData.vo) {
+      setFormData((prev) => ({ ...prev, vo: oidcGroups[0] }));
+    }
+  }, [formData.vo, oidcGroups]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setFormData((prev) => ({
+      ...prev,
+      name: nameService(),
+      cpuCores: "0.5",
+      memoryRam: "512",
+      memoryUnit: "Mi",
+      storageMode: volumeSupportEnabled ? "volume" : "bucket",
+      bucket: "",
+      volume: "",
+      token: genRandomString(128),
+    }));
+    setNewBucket(false);
+    setVolumes([]);
+    setErrors({
+      name: false,
+      cpuCores: false,
+      memoryRam: false,
+      storage: false,
+      vo: false,
+    });
+  }, [isOpen, volumeSupportEnabled]);
+
+  useEffect(() => {
+    if (!isOpen || !volumeSupportEnabled) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadVolumes = async () => {
+      try {
+        const nextVolumes = await getVolumesApi();
+
+        if (!cancelled) {
+          setVolumes(nextVolumes);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error(error);
+          setVolumes([]);
+        }
+      }
+    };
+
+    void loadVolumes();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, volumeSupportEnabled]);
+
+  const handleDeploy = async () => {
+    const selectedBucket = formData.bucket.trim();
+    const selectedVolume = formData.volume.trim();
+    const usesVolume = formData.storageMode === "volume";
+    const usesBucket = formData.storageMode === "bucket";
+    const newErrors = {
+      name: !formData.name,
+      cpuCores: !formData.cpuCores,
+      memoryRam: !formData.memoryRam,
+      storage: usesVolume ? !selectedVolume : !selectedBucket,
+      vo: !formData.vo,
+    };
+
+    setErrors(newErrors);
+
+    if (Object.values(newErrors).some((error) => error)) {
+      alert.error("Please fill in all fields");
+      return;
+    }
+
+    try {
+      const fdlResponse = await fetch(FILEBROWSER_FDL_URL, fetchFromGitHubOptions);
+      const fdlText = await fdlResponse.text();
+      const scriptResponse = await fetch(
+        FILEBROWSER_SCRIPT_URL,
+        fetchFromGitHubOptions
+      );
+      const scriptText = await scriptResponse.text();
+      const services = yamlToServices(fdlText, scriptText);
+
+      if (!services?.length) {
+        throw new Error("No services found");
+      }
+
+      const service = services[0];
+      const serviceName = formData.name || nameService();
+      const sourcePath = usesVolume ? "/data" : `/mnt/${selectedBucket}`;
+
+      const modifiedService: Service = {
+        ...service,
+        name: serviceName,
+        vo: formData.vo,
+        token: formData.token,
+        memory: `${formData.memoryRam}${formData.memoryUnit}`,
+        cpu: formData.cpuCores,
+        mount: usesBucket
+          ? {
+              path: selectedBucket,
+              storage_provider: service.mount?.storage_provider ?? "minio.default",
+            }
+          : undefined,
+        volume: usesVolume
+          ? {
+              name: selectedVolume,
+              mount_path: "/data",
+            }
+          : undefined,
+        environment: {
+          variables: {
+            ...service.environment.variables,
+            FILEBROWSER_SOURCE_PATH: sourcePath,
+          },
+          secrets: {
+            ...service.environment.secrets,
+          },
+        },
+        labels: {
+          ...service.labels,
+          filebrowser: "true",
+        },
+      };
+
+      await createServiceApi(modifiedService);
+      refreshServices();
+
+      alert.success("File Browser instance deployed");
+      setIsOpen(false);
+    } catch (error) {
+      console.error(error);
+      alert.error(`Error deploying File Browser instance: ${errorMessage(error)}`);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant="mainGreen"
+          tooltipLabel="New File Browser Instance"
+          onClick={() => {
+            setIsOpen(false);
+          }}
+        >
+          <Plus size={20} className="mr-2" />
+          New
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[90%] max-w-[600px] gap-4 flex flex-col">
+        <DialogHeader>
+          <DialogTitle>
+            <span style={{ color: OscarColors.DarkGrayText }}>
+              File Browser Instance Configuration
+            </span>
+          </DialogTitle>
+        </DialogHeader>
+        <hr />
+        <div className="grid grid-cols-1 gap-y-2 sm:gap-x-2 overflow-y-auto">
+          <div>
+            <div className="flex flex-row items-center">
+              <Label>Service name</Label>
+              <Button
+                variant="link"
+                size="icon"
+                onClick={() => setFormData({ ...formData, name: nameService() })}
+              >
+                <RefreshCcwIcon size={16} />
+              </Button>
+            </div>
+            <Input
+              id="name"
+              placeholder="Enter service name"
+              value={formData.name}
+              className={errors.name ? "border-red-500 focus:border-red-500" : ""}
+              onChange={(e) => {
+                setFormData({ ...formData, name: e.target.value });
+                if (errors.name) {
+                  setErrors({ ...errors, name: false });
+                }
+              }}
+            />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 items-end">
+            <div>
+              <Label htmlFor="cpu-cores">CPU Cores</Label>
+              <Input
+                id="cpu-cores"
+                type="number"
+                step={0.1}
+                placeholder="Enter CPU Cores"
+                value={formData.cpuCores}
+                className={errors.cpuCores ? "border-red-500 focus:border-red-500" : ""}
+                onChange={(e) => {
+                  setFormData({ ...formData, cpuCores: e.target.value });
+                  if (errors.cpuCores) {
+                    setErrors({ ...errors, cpuCores: false });
+                  }
+                }}
+              />
+            </div>
+            <div className="grid grid-cols-[1fr_auto] gap-2 items-end">
+              <div>
+                <Label htmlFor="memory-ram">RAM</Label>
+                <Input
+                  id="memory-ram"
+                  type="number"
+                  step={formData.memoryUnit === "Gi" ? 1 : 128}
+                  placeholder="Enter RAM"
+                  value={formData.memoryRam}
+                  className={errors.memoryRam ? "border-red-500 focus:border-red-500" : ""}
+                  onChange={(e) => {
+                    setFormData({ ...formData, memoryRam: e.target.value });
+                    if (errors.memoryRam) {
+                      setErrors({ ...errors, memoryRam: false });
+                    }
+                  }}
+                />
+              </div>
+              <Select
+                value={formData.memoryUnit}
+                onValueChange={(value) =>
+                  setFormData({ ...formData, memoryUnit: value })
+                }
+              >
+                <SelectTrigger className="w-[80px]">
+                  <SelectValue id="memory-unit" placeholder="Unit" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Gi">Gi</SelectItem>
+                  <SelectItem value="Mi">Mi</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="vo">VO</Label>
+            <Select
+              value={formData.vo}
+              onValueChange={(value) => {
+                setFormData({ ...formData, vo: value });
+                if (errors.vo) {
+                  setErrors({ ...errors, vo: false });
+                }
+              }}
+            >
+              <SelectTrigger
+                id="vo"
+                className={errors.vo ? "border-red-500 focus:border-red-500" : ""}
+              >
+                <SelectValue placeholder="Select a VO" />
+              </SelectTrigger>
+              <SelectContent>
+                {oidcGroups.map((group) => (
+                  <SelectItem key={group} value={group}>
+                    {group}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor="storage-mode">Storage</Label>
+            <Select
+              value={formData.storageMode}
+              onValueChange={(value) => {
+                setFormData({
+                  ...formData,
+                  storageMode: value as StorageMode,
+                  bucket: "",
+                  volume: "",
+                });
+                if (errors.storage) {
+                  setErrors({ ...errors, storage: false });
+                }
+              }}
+            >
+              <SelectTrigger id="storage-mode">
+                <SelectValue placeholder="Select storage type" />
+              </SelectTrigger>
+              <SelectContent>
+                {volumeSupportEnabled && (
+                  <SelectItem value="volume">Existing volume</SelectItem>
+                )}
+                <SelectItem value="bucket">MinIO bucket</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {formData.storageMode === "volume" ? (
+            <div>
+              <Label htmlFor="volume">Volume</Label>
+              <Select
+                value={formData.volume}
+                onValueChange={(value) => {
+                  setFormData({ ...formData, volume: value });
+                  if (errors.storage) {
+                    setErrors({ ...errors, storage: false });
+                  }
+                }}
+              >
+                <SelectTrigger
+                  id="volume"
+                  className={errors.storage ? "border-red-500 focus:border-red-500" : ""}
+                >
+                  <SelectValue placeholder="Select a volume" />
+                </SelectTrigger>
+                <SelectContent>
+                  {volumes.map((volume) => (
+                    <SelectItem key={volume.name} value={volume.name}>
+                      {volume.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : (
+            <div>
+              <Label>Bucket</Label>
+              <div>
+                <Label className="inline-flex items-center cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={newBucket}
+                    className="sr-only peer"
+                    onChange={() => {
+                      setNewBucket(!newBucket);
+                      setFormData({ ...formData, bucket: "" });
+                    }}
+                  />
+                  <div className="relative w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-teal-600 dark:peer-checked:bg-teal-600"></div>
+                  <span className="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">
+                    New Bucket
+                  </span>
+                </Label>
+                {newBucket ? (
+                  <Input
+                    value={formData.bucket}
+                    className={errors.storage ? "border-red-500 focus:border-red-500" : ""}
+                    onChange={(e) => {
+                      setFormData({ ...formData, bucket: e.target.value });
+                      if (errors.storage) {
+                        setErrors({ ...errors, storage: false });
+                      }
+                    }}
+                    placeholder="Enter bucket name"
+                  />
+                ) : (
+                  <Select
+                    value={formData.bucket}
+                    onValueChange={(value) => {
+                      setFormData({ ...formData, bucket: value });
+                      if (errors.storage) {
+                        setErrors({ ...errors, storage: false });
+                      }
+                    }}
+                  >
+                    <SelectTrigger
+                      className={errors.storage ? "border-red-500 focus:border-red-500" : ""}
+                    >
+                      <SelectValue placeholder="Select a bucket" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {buckets.map((bucket) => (
+                        <SelectItem
+                          key={bucket.bucket_name}
+                          value={bucket.bucket_name}
+                        >
+                          {bucket.bucket_name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <RequestButton
+            className="grid grid-cols-[auto] sm:grid-cols-1 gap-2"
+            variant="mainGreen"
+            request={handleDeploy}
+          >
+            Deploy
+          </RequestButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default FileBrowserFormPopover;

--- a/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
+++ b/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
@@ -38,9 +38,9 @@ import { Plus, RefreshCcwIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 
 const FILEBROWSER_FDL_URL =
-  "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/feat-add-filebrowser/crates/filebrowser-quantum/fdl.yml";
+  "https://raw.githubusercontent.com/grycap/oscar-filebrowser/refs/heads/main/fdl.yml";
 const FILEBROWSER_SCRIPT_URL =
-  "https://raw.githubusercontent.com/grycap/oscar-hub/refs/heads/feat-add-filebrowser/crates/filebrowser-quantum/script.sh";
+  "https://raw.githubusercontent.com/grycap/oscar-filebrowser/refs/heads/main/script.sh";
 
 type StorageMode = "volume" | "bucket";
 

--- a/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
+++ b/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
@@ -205,6 +205,7 @@ function FileBrowserFormPopover() {
           variables: {
             ...service.environment.variables,
             FILEBROWSER_SOURCE_PATH: sourcePath,
+            FILEBROWSER_JWT_SUB: "oscar-dashboard",
           },
           secrets: {
             ...service.environment.secrets,

--- a/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
+++ b/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
@@ -205,7 +205,7 @@ function FileBrowserFormPopover() {
           variables: {
             ...service.environment.variables,
             FILEBROWSER_SOURCE_PATH: sourcePath,
-            FILEBROWSER_JWT_SUB: "oscar-dashboard",
+            FILEBROWSER_JWT_SUB: "user",
           },
           secrets: {
             ...service.environment.secrets,

--- a/src/pages/ui/filebrowsers/index.tsx
+++ b/src/pages/ui/filebrowsers/index.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import useServicesContext from "../services/context/ServicesContext";
+import IntegratedApp from "@/components/IntegratedApp";
+import FileBrowserFormPopover from "./components/FileBrowserFormPopover";
+
+function FileBrowsersView() {
+  const { authData } = useAuth();
+  const { services } = useServicesContext();
+
+  const ownerName =
+    authData?.egiSession?.sub ??
+    authData?.token ??
+    (authData?.user === "oscar" ? "cluster_admin" : authData?.user);
+  const fileBrowserServices = services.filter(
+    (service) =>
+      (service.owner === ownerName || ownerName === "cluster_admin") &&
+      service.labels["filebrowser"] === "true"
+  );
+
+  useEffect(() => {
+    document.title = "OSCAR - File Browsers";
+  }, []);
+
+  return (
+    <div className="flex flex-col h-full w-full">
+      <IntegratedApp
+        appName="File Browsers"
+        deployedServiceEndpoint={authData.endpoint}
+        filteredServices={fileBrowserServices}
+        DeployInstancePopover={FileBrowserFormPopover}
+        additionalExposedPathArgs="?jwt={{jwt.service.token}}"
+      />
+    </div>
+  );
+}
+
+export default FileBrowsersView;

--- a/src/pages/ui/filebrowsers/index.tsx
+++ b/src/pages/ui/filebrowsers/index.tsx
@@ -29,7 +29,8 @@ function FileBrowsersView() {
         deployedServiceEndpoint={authData.endpoint}
         filteredServices={fileBrowserServices}
         DeployInstancePopover={FileBrowserFormPopover}
-        additionalExposedPathArgs="?jwt={{jwt.service.token}}"
+        authActionPathArgs="api/auth/renew?jwt={{jwt.service.token}}"
+        targetExposedPath="files/"
       />
     </div>
   );

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -14,6 +14,7 @@ import { ServicesProvider } from "@/pages/ui/services/context/ServicesContext";
 import JunoView from "@/pages/ui/juno";
 import FlowsView from "@/pages/ui/flows";
 import TerminalView from "@/pages/ui/terminals";
+import FileBrowsersView from "@/pages/ui/filebrowsers";
 // Add the dashboard route
 import Cluster from "@/pages/ui/cluster_info"
 import HubView from "@/pages/ui/hub";
@@ -46,6 +47,7 @@ function AppRouter() {
           <Route path="notebooks" element={<JunoView />} />
           <Route path="flows" element={<FlowsView />} />
           <Route path="terminals" element={<TerminalView />} />
+          <Route path="filebrowsers" element={<FileBrowsersView />} />
           <Route path="status" element={<Cluster />} />
           <Route path="hub" element={<HubView />} />
           <Route path="quotas" element={


### PR DESCRIPTION
## Summary

Adds FileBrowser support as an integrated Dashboard application.

The Dashboard can now deploy FileBrowser services backed by either an existing OSCAR volume or a MinIO bucket, and it lists deployed FileBrowser services from the new “File Browsers” view.

## Changes

- Add “File Browsers” integrated app entry and route.
- Add deployment form for FileBrowser instances.
- Load the FileBrowser FDL and startup script from `grycap/oscar-filebrowser`.
- Support storage selection:
  - existing OSCAR volume
  - existing or new MinIO bucket
- Generate service-specific JWT login URLs.
- Renew the FileBrowser session before opening the app so users enter directly without the login form.
- Use the generic JWT user `user`.
- Keep existing integrated app behavior for Juno and terminals unchanged.

## Validation

- `npm run build` passes.
- Tested local deployment flow from the Dashboard.
- Verified FileBrowser opens through the Dashboard link using the transparent JWT session flow.