### PR TITLE
[codex] Add service visibility controls

### DIFF
--- a/src/api/services/getServiceApi.ts
+++ b/src/api/services/getServiceApi.ts
@@ -1,9 +1,10 @@
+import { Service } from "@/pages/ui/services/models/service";
 import axios from "axios";
 
-async function getServiceApi(serviceName:string) {
+async function getServiceApi(serviceName:string): Promise<Service> {
   const response = await axios.get("/system/services/"+serviceName);
 
-  return response;
+  return response.data as Service;
 }
 
 export default getServiceApi;

--- a/src/components/IntegratedApp/index.tsx
+++ b/src/components/IntegratedApp/index.tsx
@@ -86,11 +86,18 @@ function IntegratedApp({
 
       const failedServices = results
         .filter((result) => result.status === "rejected")
-        .map((result) => (result as {
+        .map((result) => {
+          const rejectedResult = result as {
           status: string;
           service: Service;
-          error: any;
-        }).service);
+          error: unknown;
+          };
+
+          return {
+            service: rejectedResult.service,
+            message: errorMessage(rejectedResult.error),
+          };
+        });
       
       await handleGetServices();
 
@@ -100,9 +107,11 @@ function IntegratedApp({
 
       if (failedServices.length > 0) {
         alert.error(
-          `Error deleting the following services: ${failedServices
-            .map((service) => service.name)
-            .join(", ")}`
+          failedServices.length === 1
+            ? failedServices[0].message
+            : failedServices
+              .map(({ service, message }) => `${service.name}: ${message}`)
+              .join("\n")
         );
       }
 

--- a/src/globals.css
+++ b/src/globals.css
@@ -36,3 +36,30 @@ body {
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
 }
+
+.toast-message-scroll {
+  white-space: pre-line;
+  display: block;
+  max-height: 200px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(20, 20, 20, 0.75) rgba(255, 255, 255, 0.2);
+}
+
+.toast-message-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+
+.toast-message-scroll::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+}
+
+.toast-message-scroll::-webkit-scrollbar-thumb {
+  background: rgba(20, 20, 20, 0.75);
+  border-radius: 999px;
+}
+
+.toast-message-scroll::-webkit-scrollbar-thumb:hover {
+  background: rgba(20, 20, 20, 0.9);
+}

--- a/src/lib/alert.ts
+++ b/src/lib/alert.ts
@@ -5,12 +5,26 @@ import { toast } from "sonner";
 class ToastAlert {
   constructor() {}
 
+  private formatMessage(message: React.ReactNode | string) {
+    if (typeof message === "string") {
+      return React.createElement(
+        "span",
+        {
+          className: "toast-message-scroll w-full",
+        },
+        message
+      );
+    }
+
+    return message;
+  }
+
   default(message: React.ReactNode | string) {
-    toast(message);
+    toast(this.formatMessage(message));
   }
 
   success(message: string) {
-    toast.success(message, {
+    toast.success(this.formatMessage(message), {
       style: {
         backgroundColor: "#17A34B",
         color: "white",
@@ -24,7 +38,7 @@ class ToastAlert {
       console.error(message);
     }
 
-    toast.error(message, {
+    toast.error(this.formatMessage(message), {
       style: {
         backgroundColor: OscarColors.Red,
         color: "white",
@@ -38,7 +52,7 @@ class ToastAlert {
       console.warn(messsage);
     }
 
-    toast.warning(messsage, {
+    toast.warning(this.formatMessage(messsage), {
       style: {
         backgroundColor: "orange",
         color: "white",

--- a/src/pages/ui/services/components/FDL/utils/yamlToService.ts
+++ b/src/pages/ui/services/components/FDL/utils/yamlToService.ts
@@ -1,5 +1,5 @@
 import YAML from "yaml";
-import { Service } from "../../../models/service";
+import { Service, ServiceVisibility } from "../../../models/service";
 import { alert } from "@/lib/alert";
 import { errorMessage } from "@/lib/error";
 
@@ -15,6 +15,11 @@ const yamlToServices = (fdlString: string, scriptString: string) => {
         serviceParams.script = scriptContent;
         serviceParams.storage_providers = obj.storage_providers || {};
         serviceParams.clusters = obj.clusters || {};
+        serviceParams.visibility = serviceParams.visibility ?? ServiceVisibility.private;
+        serviceParams.allowed_users =
+          serviceParams.visibility === ServiceVisibility.restricted
+            ? serviceParams.allowed_users ?? []
+            : [];
         services.push(serviceParams);
       });
     }

--- a/src/pages/ui/services/components/ServiceForm/components/GeneralTab/index.tsx
+++ b/src/pages/ui/services/components/ServiceForm/components/GeneralTab/index.tsx
@@ -1,6 +1,10 @@
 import { Input } from "@/components/ui/input";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
-import { LOG_LEVEL, Service } from "@/pages/ui/services/models/service";
+import {
+  LOG_LEVEL,
+  Service,
+  ServiceVisibility,
+} from "@/pages/ui/services/models/service";
 import {
   Select,
   SelectContent,
@@ -49,6 +53,9 @@ function ServiceGeneralTab() {
     }));
   };
 
+  const visibility = formService?.visibility ?? ServiceVisibility.private;
+  const serviceIsRestricted = visibility === ServiceVisibility.restricted;
+
   return (
     <div
       style={{
@@ -92,7 +99,7 @@ function ServiceGeneralTab() {
             </div>
           </div>
           
-          <div className="grid grid-cols-[auto_auto_1fr] gap-5 items-end w-full">
+          <div className="grid grid-cols-[auto_auto_auto_1fr] gap-5 items-end w-full">
             <div className="min-w-[154px]">
               {voGroupsIsEmpthy() ?
                <></>
@@ -155,6 +162,37 @@ function ServiceGeneralTab() {
                 </SelectContent>
               </Select>
             </div>
+            <div className="min-w-[152px]">
+              <Label>Visibility</Label>
+              <Select
+                value={visibility}
+                onValueChange={(value: ServiceVisibility) => {
+                  setFormService((service: Service) => {
+                    return {
+                      ...service,
+                      visibility: value,
+                      allowed_users:
+                        value === ServiceVisibility.restricted
+                          ? service.allowed_users
+                          : [],
+                    };
+                  });
+                }}
+              >
+                <SelectTrigger id="visibility-select-trigger">
+                  <SelectValue placeholder="Visibility" />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.values(ServiceVisibility).map((value) => {
+                    return (
+                      <SelectItem key={value} value={value}>
+                        {value}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
             {formService.token && (
               <div 
                className="col-span-1"
@@ -181,6 +219,16 @@ function ServiceGeneralTab() {
               </div>
             )}
           </div>
+
+          {serviceIsRestricted && (
+            <div className="flex flex-row gap-2 items-center">
+              <strong>Allowed users:</strong>
+              <AllowedUsersPopover
+                allowed_users={formService.allowed_users ?? []}
+                setAllowedUsersInExternalVar={setAllowedUsers}
+              />
+            </div>
+          )}
 
           {formMode === ServiceViewMode.Update && (
             <div
@@ -225,8 +273,8 @@ function ServiceGeneralTab() {
               </div>
 
               <div className="flex flex-row gap-2 items-center">
-                <strong>Allowed users:</strong>
-                  <AllowedUsersPopover allowed_users={formService.allowed_users} setAllowedUsersInExternalVar={setAllowedUsers}/>
+                <strong>Visibility:</strong>
+                {visibility}
               </div>
             </div>
           )}

--- a/src/pages/ui/services/components/ServiceForm/components/GeneralTab/index.tsx
+++ b/src/pages/ui/services/components/ServiceForm/components/GeneralTab/index.tsx
@@ -186,7 +186,7 @@ function ServiceGeneralTab() {
                   {Object.values(ServiceVisibility).map((value) => {
                     return (
                       <SelectItem key={value} value={value}>
-                        {value}
+                        {value.toUpperCase()}
                       </SelectItem>
                     );
                   })}
@@ -219,16 +219,6 @@ function ServiceGeneralTab() {
               </div>
             )}
           </div>
-
-          {serviceIsRestricted && (
-            <div className="flex flex-row gap-2 items-center">
-              <strong>Allowed users:</strong>
-              <AllowedUsersPopover
-                allowed_users={formService.allowed_users ?? []}
-                setAllowedUsersInExternalVar={setAllowedUsers}
-              />
-            </div>
-          )}
 
           {formMode === ServiceViewMode.Update && (
             <div
@@ -274,8 +264,17 @@ function ServiceGeneralTab() {
 
               <div className="flex flex-row gap-2 items-center">
                 <strong>Visibility:</strong>
-                {visibility}
+                {visibility?.toUpperCase()}
               </div>
+              {serviceIsRestricted && (
+                <div className="flex flex-row gap-2 items-center">
+                  <strong>Allowed users:</strong>
+                  <AllowedUsersPopover
+                    allowed_users={formService.allowed_users ?? []}
+                    setAllowedUsersInExternalVar={setAllowedUsers}
+                  />
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/pages/ui/services/components/ServiceForm/utils/initialData.ts
+++ b/src/pages/ui/services/components/ServiceForm/utils/initialData.ts
@@ -1,4 +1,4 @@
-import { Service, LOG_LEVEL } from "../../../models/service";
+import { Service, LOG_LEVEL, ServiceVisibility } from "../../../models/service";
 
 export const defaultService: Service = {
   name: "",
@@ -46,6 +46,7 @@ export const defaultService: Service = {
   },
   interlink_node_name: "",
   allowed_users: [],
+  visibility: ServiceVisibility.private,
   expose: {
     min_scale: "",
     max_scale: "",

--- a/src/pages/ui/services/components/ServicesList/domain/filterUtils.ts
+++ b/src/pages/ui/services/components/ServicesList/domain/filterUtils.ts
@@ -3,13 +3,25 @@ import {
   Service,
   ServiceFilter,
   ServiceFilterByKey,
-  ServiceVisibility,
 } from "../../../models/service";
 
 interface Props {
   services: Service[];
   filter: ServiceFilter;
   authData: AuthData;
+}
+
+function handleServiceVisibilityFilter(services: Service, filter: ServiceFilter) {
+  if (filter.onlyPrivate && services.visibility !== "private") {
+    return false;
+  }
+  if (filter.onlyPublic && services.visibility !== "public") {
+    return false;
+  }
+  if (filter.onlyRestricted && services.visibility !== "restricted") {
+    return false;
+  }
+  return true;
 }
 
 function handleFilterServices({ services, filter, authData }: Props) {
@@ -24,16 +36,15 @@ function handleFilterServices({ services, filter, authData }: Props) {
         );
       }
 
-      if (!service.owner.includes(egiUserId)) {
+      if (!service.owner.includes(egiUserId) && handleServiceVisibilityFilter(service, filter)) {
         return false;
       }
     }
+    if (!handleServiceVisibilityFilter(service, filter)) {
+      return false;
+    }
 
-    const key = ServiceFilterByKey[filter.type];
-    const param =
-      key === "visibility"
-        ? service.visibility ?? ServiceVisibility.private
-        : service[key] as string;
+    const param = service[ServiceFilterByKey[filter.type]] as string;
 
     return param.toLowerCase().includes(filter.value.toLowerCase());
   });

--- a/src/pages/ui/services/components/ServicesList/domain/filterUtils.ts
+++ b/src/pages/ui/services/components/ServicesList/domain/filterUtils.ts
@@ -3,6 +3,7 @@ import {
   Service,
   ServiceFilter,
   ServiceFilterByKey,
+  ServiceVisibility,
 } from "../../../models/service";
 
 interface Props {
@@ -28,7 +29,11 @@ function handleFilterServices({ services, filter, authData }: Props) {
       }
     }
 
-    const param = service[ServiceFilterByKey[filter.type]] as string;
+    const key = ServiceFilterByKey[filter.type];
+    const param =
+      key === "visibility"
+        ? service.visibility ?? ServiceVisibility.private
+        : service[key] as string;
 
     return param.toLowerCase().includes(filter.value.toLowerCase());
   });

--- a/src/pages/ui/services/components/ServicesList/index.tsx
+++ b/src/pages/ui/services/components/ServicesList/index.tsx
@@ -4,7 +4,7 @@ import getServicesApi from "@/api/services/getServicesApi";
 import deleteServiceApi from "@/api/services/deleteServiceApi";
 import { alert } from "@/lib/alert";
 import DeleteDialog from "@/components/DeleteDialog";
-import { Service } from "../../models/service";
+import { Service, ServiceVisibility } from "../../models/service";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { LoaderPinwheel, Pencil, RefreshCw, Terminal, Trash2 } from "lucide-react";
@@ -29,6 +29,12 @@ interface DeploymentStatusCellProps {
   onNavigate: () => void;
   eagerLoad?: boolean;
 }
+
+const visibilityBadgeColors = {
+  [ServiceVisibility.private]: "bg-slate-100 text-slate-800 border-slate-200",
+  [ServiceVisibility.restricted]: "bg-amber-100 text-amber-900 border-amber-200",
+  [ServiceVisibility.public]: "bg-green-100 text-green-900 border-green-200",
+};
 
 function DeploymentStatusCell({ initialDeployment, serviceName, onNavigate, eagerLoad }: DeploymentStatusCellProps) {
   const [deployment, setDeployment] = useState<DeploymentStatus | undefined>(initialDeployment);
@@ -113,11 +119,18 @@ function ServicesList() {
 
       const failedServices = results
         .filter((result) => result.status === "rejected")
-        .map((result) => (result as {
+        .map((result) => {
+          const rejectedResult = result as {
           status: string;
           service: Service;
           error: unknown;
-        }).service);
+          };
+
+          return {
+            service: rejectedResult.service,
+            message: errorMessage(rejectedResult.error),
+          };
+        });
       
       await handleGetServices();
 
@@ -127,9 +140,11 @@ function ServicesList() {
 
       if (failedServices.length > 0) {
         alert.error(
-          `Error deleting the following services: ${failedServices
-            .map((service) => service.name)
-            .join(", ")}`
+          failedServices.length === 1
+            ? failedServices[0].message
+            : failedServices
+              .map(({ service, message }) => `${service.name}: ${message}`)
+              .join("\n")
         );
       }
 
@@ -194,6 +209,22 @@ function ServicesList() {
                 sortBy: "deployment",
               }] as ColumnDef<Service>[] : []),
               { header: "Owner", accessor: (row) => (<ResponsiveOwnerField owner={row.labels["owner_name"] ? shortenFullname(row.labels["owner_name"].replace("_", " ")) : row.owner} sub={row.owner} />), sortBy: "owner" },
+              {
+                header: "Visibility",
+                accessor: (row) => {
+                  const visibility = row.visibility ?? ServiceVisibility.private;
+
+                  return (
+                    <Badge
+                      variant="outline"
+                      className={visibilityBadgeColors[visibility]}
+                    >
+                      {visibility.toUpperCase()}
+                    </Badge>
+                  );
+                },
+                sortBy: "visibility",
+              },
               { header: "Image", accessor: "image", sortBy: "image" },
               { header: "CPU", accessor: "cpu", sortBy: "cpu" },
               { header: "Memory", accessor: "memory", sortBy: "memory" },

--- a/src/pages/ui/services/components/Topbar/components/CreateUpdateButton.tsx
+++ b/src/pages/ui/services/components/Topbar/components/CreateUpdateButton.tsx
@@ -5,7 +5,7 @@ import createServiceApi from "@/api/services/createServiceApi";
 import { alert } from "@/lib/alert";
 import updateServiceApi from "@/api/services/updateServiceApi";
 import { useMemo } from "react";
-import { Service } from "../../../models/service";
+import { Service, ServiceVisibility } from "../../../models/service";
 import getServicesApi from "@/api/services/getServicesApi";
 import { useNavigate } from "react-router-dom";
 import RequestButton from "@/components/RequestButton";
@@ -20,6 +20,8 @@ export function CreateUpdateServiceButton({ isInCreateMode }: Props) {
   const { setErrors } = formFunctions;
 
   const createServiceModel = useMemo(() => {
+    const visibility = formService.visibility ?? ServiceVisibility.private;
+
     return {
       cpu: formService.cpu,
       image: formService.image,
@@ -33,6 +35,11 @@ export function CreateUpdateServiceButton({ isInCreateMode }: Props) {
       output: formService.output,
       script: formService.script,
       environment: formService.environment,
+      visibility,
+      allowed_users:
+        visibility === ServiceVisibility.restricted
+          ? formService.allowed_users
+          : [],
       valid: true,
     };
   }, [formService]);
@@ -57,12 +64,21 @@ export function CreateUpdateServiceButton({ isInCreateMode }: Props) {
       return;
     }
     try {
+      const serviceToUpdate = {
+        ...formService,
+        visibility: formService.visibility ?? ServiceVisibility.private,
+        allowed_users:
+          formService.visibility === ServiceVisibility.restricted
+            ? formService.allowed_users
+            : [],
+      };
+
       if (isInCreateMode) {
         await createServiceApi(createServiceModel as unknown as Service);
         alert.success("Service created successfully");
         navigate(`/ui/services/${createServiceModel.name}/settings`);
       } else {
-        await updateServiceApi(formService);
+        await updateServiceApi(serviceToUpdate);
         alert.success("Service updated successfully");
       }
 

--- a/src/pages/ui/services/components/Topbar/components/FilterBy.tsx
+++ b/src/pages/ui/services/components/Topbar/components/FilterBy.tsx
@@ -55,12 +55,100 @@ function ServicesFilterBy() {
         </SelectTrigger>
         <SelectContent>
           {Object.values(ServiceFilterBy).map((value) => {
+            if (value === ServiceFilterBy.Visibility) {
+              return null; // We handle visibility with separate checkboxes, so we skip it in the dropdown
+            }
             return (
               <SelectItem key={value} value={value}>
                 {"By " + value.toLocaleLowerCase()}
               </SelectItem>
             );
           })}
+          <Divider />
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              padding: "6px",
+            }}
+          >
+            <Checkbox
+              id="privateItems"
+              checked={filter.onlyPrivate}
+              onCheckedChange={(checked) => {
+                setFilter((prev) => ({
+                  ...prev,
+                  onlyPrivate: checked as boolean,
+                  onlyPublic: false,
+                  onlyRestricted: false,
+                }));
+              }}
+              style={{ fontSize: 16 }}
+            />
+            <label
+              htmlFor="privateItems"
+              style={{ fontSize: 14, marginTop: "1px" }}
+            >
+              Private Svc.
+            </label>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              padding: "6px",
+            }}
+          >
+            <Checkbox
+              id="publicItems"
+              checked={filter.onlyPublic}
+              onCheckedChange={(checked) => {
+                setFilter((prev) => ({
+                  ...prev,
+                  onlyPublic: checked as boolean,
+                  onlyPrivate: false,
+                  onlyRestricted: false,
+                }));
+              }}
+              style={{ fontSize: 16 }}
+            />
+            <label
+              htmlFor="publicItems"
+              style={{ fontSize: 14, marginTop: "1px" }}
+            >
+              Public Svc.
+            </label>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              padding: "6px",
+            }}
+          >
+            <Checkbox
+              id="restrictedItems"
+              checked={filter.onlyRestricted}
+              onCheckedChange={(checked) => {
+                setFilter((prev) => ({
+                  ...prev,
+                  onlyRestricted: checked as boolean,
+                  onlyPrivate: false,
+                  onlyPublic: false,
+                }));
+              }}
+              style={{ fontSize: 16 }}
+            />
+            <label
+              htmlFor="restrictedItems"
+              style={{ fontSize: 14, marginTop: "1px" }}
+            >
+              Restricted Svc.
+            </label>
+          </div>
           <Divider />
           <div
             style={{

--- a/src/pages/ui/services/context/ServicesContext.tsx
+++ b/src/pages/ui/services/context/ServicesContext.tsx
@@ -103,6 +103,9 @@ export const ServicesProvider = ({
     value: "",
     type: ServiceFilterBy.Name,
     onlyOwned: false,
+    onlyPrivate: false,
+    onlyPublic: false,
+    onlyRestricted: false,
   } as ServiceFilter);
 
   //Active tab in create/update mode

--- a/src/pages/ui/services/context/ServicesContext.tsx
+++ b/src/pages/ui/services/context/ServicesContext.tsx
@@ -15,9 +15,9 @@ import {
   ServiceVisibility,
 } from "../models/service";
 import getServicesApi from "@/api/services/getServicesApi";
+import getServiceApi from "@/api/services/getServiceApi";
 import { useLocation } from "react-router-dom";
 import { defaultService } from "../components/ServiceForm/utils/initialData";
-import useUpdate from "@/hooks/useUpdate";
 import getSystemConfigApi from "@/api/config/getSystemConfig";
 import { ServiceViewMode } from "../components/Topbar";
 import { z } from "zod";
@@ -184,12 +184,15 @@ export const ServicesProvider = ({
 
   async function handleGetServices() {
     setServicesAreLoading(true);
-    const response = await getServicesApi();
-    setServicesAreLoading(false);
-
-    setServices(response);
-
-    handleFormService(response);
+    try {
+      const response = await getServicesApi();
+      setServices(response);
+      if (serviceId && serviceId !== "create") {
+        await handleFormService();
+      }
+    } finally {
+      setServicesAreLoading(false);
+    }
   }
 
   async function getDefaultService() {
@@ -206,17 +209,25 @@ export const ServicesProvider = ({
     } as Service;
   }
 
-  async function handleFormService(services: Service[]) {
+  async function handleFormService() {
+    setErrors({});
+
     if (!serviceId || serviceId === "create") {
       const defaultService = await getDefaultService();
       setFormService(defaultService);
+      setErrors({});
       return;
     }
 
-    if (!services) return;
-    const selectedService = services.find((s) => s.name === serviceId);
-    if (!selectedService) return;
-    setFormService(selectedService);
+    setFormService({} as Service);
+
+    try {
+      const selectedService = await getServiceApi(serviceId);
+      setFormService(selectedService);
+      setErrors({});
+    } catch (error) {
+      alert.error(`Error getting service: ${errorMessage(error)}`);
+    }
   }
 
   useEffect(() => {
@@ -224,12 +235,12 @@ export const ServicesProvider = ({
   }, []);
 
   useEffect(() => {
+    handleFormService();
+  }, [serviceId]);
+
+  useEffect(() => {
     localStorage.setItem("eagerLoadDeployment", String(eagerLoadDeployment));
   }, [eagerLoadDeployment]);
-
-  useUpdate(() => {
-    handleFormService(services);
-  }, [serviceId]);
 
   return (
     <ServicesContext.Provider

--- a/src/pages/ui/services/context/ServicesContext.tsx
+++ b/src/pages/ui/services/context/ServicesContext.tsx
@@ -12,6 +12,7 @@ import {
   ServiceFilter,
   ServiceFilterBy,
   ServiceTab,
+  ServiceVisibility,
 } from "../models/service";
 import getServicesApi from "@/api/services/getServicesApi";
 import { useLocation } from "react-router-dom";
@@ -71,6 +72,7 @@ export const serviceSchema = z.object({
   cpu: z.string().min(1, "CPU cores is required"),
   memory: z.string().min(1, "Memory is required"),
   script: z.string().min(1, "Script is required"),
+  visibility: z.nativeEnum(ServiceVisibility).optional(),
 });
 
 type SchemaKeys = keyof typeof serviceSchema.shape;

--- a/src/pages/ui/services/models/service.ts
+++ b/src/pages/ui/services/models/service.ts
@@ -4,6 +4,9 @@ export type ServiceFilter = {
   value: string;
   type: ServiceFilterBy;
   onlyOwned: boolean;
+  onlyPrivate: boolean;
+  onlyPublic: boolean;
+  onlyRestricted: boolean;
 };
 
 export enum ServiceFilterBy {

--- a/src/pages/ui/services/models/service.ts
+++ b/src/pages/ui/services/models/service.ts
@@ -10,6 +10,7 @@ export enum ServiceFilterBy {
   Name = "Name",
   Image = "Image",
   Owner = "Owner",
+  Visibility = "Visibility",
   //Type = "Type",
 }
 
@@ -17,6 +18,7 @@ export const ServiceFilterByKey: Record<ServiceFilterBy, keyof Service> = {
   [ServiceFilterBy.Name]: "name",
   [ServiceFilterBy.Image]: "image",
   [ServiceFilterBy.Owner]: "owner",
+  [ServiceFilterBy.Visibility]: "visibility",
   //[ServiceFilterBy.Type]: "",
 };
 
@@ -136,6 +138,12 @@ export enum Bucket_visibility {
   public = "public",
 }
 
+export enum ServiceVisibility {
+  private = "private",
+  restricted = "restricted",
+  public = "public",
+}
+
 export interface VolumeStatus {
   phase?: string;
   message?: string;
@@ -174,6 +182,7 @@ export interface ServiceVolumeConfig {
 
 export interface Service {
   allowed_users: string[];
+  visibility?: ServiceVisibility;
   name: string;
   cluster_id: string;
   memory: string;


### PR DESCRIPTION
## Summary

- Add service visibility support to the services UI, including private/restricted/public selection, restricted allowed users, list badges, and visibility filtering.
- Preserve backend delete error messages in service delete alerts so users see the API reason instead of a generic failed-service list.
- Load service Settings from the service detail endpoint to avoid stale or empty form state when navigating directly or after refreshes.

## Root Cause

The dashboard did not model or submit the service `visibility` field, and the Settings form depended on the global services list to populate `formService`. When that list was empty or stale, the form could validate an empty/default service and show required-field errors for service name and image.

## Validation

- `npm run lint`
- `npm run build`
