### PR TITLE
Small improvements

### DIFF
--- a/src/pages/ui/minio/components/BucketContent/index.tsx
+++ b/src/pages/ui/minio/components/BucketContent/index.tsx
@@ -249,7 +249,7 @@ export default function BucketContent() {
               Type: item.Type,
               Key: item.Key,
               Size: item.Type === "file" ? bytesSizeToHumanReadable(item.Key.Size ?? 0) : undefined,
-              LastModifTime: item.Type === "file" ? item.Key.LastModified?.toLocaleString() : undefined,
+              LastModifTime: item.Type === "file" ? item.Key.LastModified : undefined,
               BucketName: item.BucketName
           }})}
           onRowClick={(item) => {
@@ -295,7 +295,7 @@ export default function BucketContent() {
               header: "Last Modified Time",
               accessor: (item) => {
                 if (item.Type === "folder") { return ''}
-                return item.LastModifTime;
+                return item.LastModifTime?.toLocaleString();
               },
               sortBy: "LastModifTime"
             },

--- a/src/pages/ui/services/components/ServicesList/index.tsx
+++ b/src/pages/ui/services/components/ServicesList/index.tsx
@@ -7,7 +7,7 @@ import DeleteDialog from "@/components/DeleteDialog";
 import { Service } from "../../models/service";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { LoaderPinwheel, Pencil, RefreshCw, Terminal, Trash2 } from "lucide-react";
+import { ArrowDownToLine, LoaderPinwheel, Pencil, RefreshCw, Terminal, Trash2 } from "lucide-react";
 import OscarColors from "@/styles";
 import { Link, useNavigate } from "react-router-dom";
 import GenericTable, { ColumnDef } from "@/components/Table";
@@ -60,18 +60,27 @@ function DeploymentStatusCell({ initialDeployment, serviceName, onNavigate, eage
       }}
     >
       {deployment && !loading ? (
-        <>
-        <div onClick={() => {
+        <div className="flex flex-row items-center gap-1 bg-gray-300 rounded-full pr-2">
+        <div className="flex items-center" onClick={() => {
           onNavigate();
         }}>
           <DeploymentStatusBadge deployment={deployment} showTooltip className="cursor-pointer" />
         </div>
-          <RefreshCw className="h-3 w-3 opacity-40 hover:opacity-100" />
-        </>
+          <RefreshCw className="h-3 w-3 text-gray-700 opacity-90 hover:text-gray-900 hover:opacity-100" />
+        </div>
       ) : (
         <Badge variant="default" className="cursor-pointer">
-          <RefreshCw className={`${loading ? "animate-spin" : ""} h-3 w-3 mr-1`} />
-          Fetch
+          {!loading ? (
+            <>
+            <ArrowDownToLine className={`h-3 w-3 mr-1`} />
+            Get Status
+            </>
+          ) : (
+            <>
+            <RefreshCw className={`animate-spin h-3 w-3 mr-1`} />
+            Loading...
+            </>
+          )}
         </Badge>
       )}
     </div>

--- a/src/pages/ui/services/context/ServicesContext.tsx
+++ b/src/pages/ui/services/context/ServicesContext.tsx
@@ -87,7 +87,9 @@ export const ServicesProvider = ({
   const [services, setServices] = useState([] as Service[]);
   const [servicesAreLoading, setServicesAreLoading] = useState(false);
   const [eagerLoadDeployment, setEagerLoadDeployment] = useState(() => {
-    return localStorage.getItem("eagerLoadDeployment") === "true";
+    const savedValue = localStorage.getItem("eagerLoadDeployment");
+    if (savedValue === null) return true;
+    return savedValue === "true";
   });
   const [serviceLogs, setServiceLogs] = useState<{next_page: string | null, jobs: Record<string, Log>}>({next_page: null, jobs: {}});
   const [logsAreLoading, setLogsAreLoading] = useState(true);


### PR DESCRIPTION
This pull request introduces several improvements to the UI for service management and bucket content display. The most notable changes include enhancements to the deployment status cell for better user feedback, improved handling of the "eager load deployment" setting, and minor code cleanups and visual tweaks.

**UI/UX Improvements:**

* The deployment status cell in `ServicesList` now provides clearer feedback: when not loading, it shows a "Get Status" button with a download icon; while loading, it displays a spinning loader and "Loading..." text. The status badge and refresh icon are visually grouped for better clarity.
* The deployment status badge and refresh icon have improved styling for better visibility and user interaction.

**Functionality and Behavior Changes:**

* The "eager load deployment" setting in `ServicesContext` now defaults to `true` if not previously set in local storage, ensuring a better out-of-the-box experience.

**Code and Data Handling Improvements:**

* In the bucket content table, the "Last Modified Time" is now stored as a raw value and converted to a locale string only when displayed, fixing potential formatting issues and improving consistency. [[1]](diffhunk://#diff-28334ee1598e0398b708fae366f086194f6a8c5e7b15a54c24daa2fe74430ef9L252-R252) [[2]](diffhunk://#diff-28334ee1598e0398b708fae366f086194f6a8c5e7b15a54c24daa2fe74430ef9L298-R298)

**Code Cleanup:**

* The download icon (`ArrowDownToLine`) is now imported and used in the deployment status cell, replacing the previous fetch icon for better semantic meaning.

Let me know if you'd like more details on any of these changes!