### PR TITLE
Update hub conf popover

### DIFF
--- a/src/hooks/useGetPrivateBuckets.tsx
+++ b/src/hooks/useGetPrivateBuckets.tsx
@@ -2,10 +2,14 @@ import getBucketsApi from "@/api/buckets/getBucketsApi";
 import { Bucket, Bucket_visibility } from "@/pages/ui/services/models/service";
 import { useEffect, useState } from "react";
 
-function useGetPrivateBuckets() {
+function useGetPrivateBuckets(enabled: boolean = true) {
   const [ buckets, setBuckets ] = useState<Bucket[]>([]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     const fetchBuckets = async () => {
       const bucketsData = await getBucketsApi();
       const filteredBuckets = bucketsData.filter(bucket => (
@@ -14,7 +18,7 @@ function useGetPrivateBuckets() {
       setBuckets(filteredBuckets);
     };
     fetchBuckets();
-  }, []);
+  }, [enabled]);
 
   return buckets;
 }

--- a/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
+++ b/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
@@ -35,7 +35,7 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
   const {systemConfig, authData } = useAuth();
   const { refreshServices } = useServicesContext();
   const [newBucket, setNewBucket] = useState(false);
-  const buckets = useGetPrivateBuckets();
+  const buckets = useGetPrivateBuckets(isOpen);
 
   const oidcGroups = getAllowedVOs(systemConfig, authData);
 	const asyncService = roCrateServiceDef.type.some(t => t.toLowerCase() === "asynchronous");

--- a/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
+++ b/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
@@ -90,6 +90,7 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
     token: "",
     enviromentVars: {} as Record<string, string>,
     enviromentSecrets: {} as Record<string, string>,
+    nodePort: "",
   });
   const [newVolume, setNewVolume] = useState(false);
   const [volumes, setVolumes] = useState<ManagedVolume[]>([]);
@@ -119,6 +120,7 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
     token: false,
     enviromentVars: {} as Record<string, boolean>,
     enviromentSecrets: {} as Record<string, boolean>,
+    nodePort: false,
   });
 
   useEffect(() => {
@@ -143,6 +145,7 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
       token: genRandomString(128),
       enviromentVars: service.environment?.variables || {},
       enviromentSecrets: service.environment?.secrets || {},
+      nodePort: service.expose?.nodePort || "",
     }));
     setNewBucket(false);
     setVolumes([]);
@@ -158,6 +161,7 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
       token: false,
       enviromentVars: {} as Record<string, boolean>,
       enviromentSecrets: {} as Record<string, boolean>,
+      nodePort: false,
     });
 
     let cancelled = false;
@@ -219,6 +223,7 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
       token: !formData.token,
       enviromentVars: Object.fromEntries(Object.entries(formData.enviromentVars).map(([key, value]) => [key, !value || value.length === 0])),
       enviromentSecrets: Object.fromEntries(Object.entries(formData.enviromentSecrets).map(([key, value]) => [key, !value || value.length === 0])),
+      nodePort: !formData.nodePort,
     };
 
     setErrors(newErrors);
@@ -417,6 +422,22 @@ return (
                   </SelectContent>
                 </Select>
             </div>
+            {service?.expose?.nodePort && (
+              <div>
+                <Label htmlFor="nodePort">Node Port</Label>
+                <Input
+                  id="nodePort"
+                  type="number"
+                  placeholder="Enter Node Port"
+                  value={formData.nodePort}
+                  className={errors.nodePort ? "border-red-500 focus:border-red-500" : ""}
+                  onChange={(e) => {
+                    setFormData({ ...formData, nodePort: e.target.value });
+                    if (errors.nodePort) setErrors({ ...errors, nodePort: false });
+                  }}
+                />
+              </div>
+            )}
 						{(asyncService || mountBucket) && 
             <div>
               <Label>Bucket</Label>
@@ -584,55 +605,69 @@ return (
               </div>
             </div>
             }
-            {formData?.enviromentVars && Object.entries(formData.enviromentVars).map(([key, value]) => (
-            <div key={`var-${key}`}>
-              <Label>{key}</Label>
-              <Input
-                disabled={ifEndpointService(key, value, formData.name) !== value}
-                type="input"
-                value={ifEndpointService(key, value, formData.name)}
-                style={{ width: "100%",
-                  fontWeight: "normal",
-                }}
-                onChange={(e) => {
-                  setFormData((prev) => ({
-                    ...prev,
-                    enviromentVars: {
-                      ...prev.enviromentVars,
-                      [key]: e.target.value,
-                    },
-                  }));
-                  if (errors.enviromentVars && errors.enviromentVars[key]) setErrors({ ...errors, enviromentVars: { ...errors.enviromentVars, [key]: false } });
-                }}
-                placeholder={`Enter ${key}`}
-                className={errors.enviromentVars[key] ? "border-red-500 focus:border-red-500" : ""}
-              />
-            </div>
-            ))}
-            {formData?.enviromentSecrets && Object.entries(formData.enviromentSecrets).map(([key, value]) => (
-            <div key={`secret-${key}`}>
-              <Label>{key}</Label>
-              <Input
-                type="password"
-                value={value}
-                style={{ width: "100%",
-                  fontWeight: "normal",
+            {Object.keys(formData?.enviromentVars ?? {}).length > 0 && (
+            <div>
+              <Label>Environment Variables</Label>
+              <hr className="mb-2"/>
+
+              {Object.entries(formData.enviromentVars).map(([key, value]) => (
+              <div key={`var-${key}`}>
+                <Label>{key}</Label>
+                <Input
+                  disabled={ifEndpointService(key, value, formData.name) !== value}
+                  type="input"
+                  value={ifEndpointService(key, value, formData.name)}
+                  style={{ width: "100%",
+                    fontWeight: "normal",
                   }}
-                onChange={(e) => {
-                  setFormData((prev) => ({
-                    ...prev,
-                    enviromentSecrets: {
-                      ...prev.enviromentSecrets,
-                      [key]: e.target.value,
-                    },
-                  }));
-                  if (errors.enviromentSecrets && errors.enviromentSecrets[key]) setErrors({ ...errors, enviromentSecrets: { ...errors.enviromentSecrets, [key]: false } });
-                }}
-                placeholder={`Enter ${key}`}
-                className={errors.enviromentSecrets[key] ? "border-red-500 focus:border-red-500" : ""}
-              />
+                  onChange={(e) => {
+                    setFormData((prev) => ({
+                      ...prev,
+                      enviromentVars: {
+                        ...prev.enviromentVars,
+                        [key]: e.target.value,
+                      },
+                    }));
+                    if (errors.enviromentVars && errors.enviromentVars[key]) setErrors({ ...errors, enviromentVars: { ...errors.enviromentVars, [key]: false } });
+                  }}
+                  placeholder={`Enter ${key}`}
+                  className={errors.enviromentVars[key] ? "border-red-500 focus:border-red-500" : ""}
+                />
+              </div>
+              ))}
             </div>
-            ))}
+            )}
+            {Object.keys(formData?.enviromentSecrets ?? {}).length > 0 && (
+            <div>
+              <Label>Environment Secrets</Label>
+              <hr className="mb-2"/>
+              
+              {Object.entries(formData.enviromentSecrets).map(([key, value]) => (
+              <div key={`secret-${key}`}>
+                <Label>{key}</Label>
+                <Input
+                  type="password"
+                  value={value}
+                  style={{ width: "100%",
+                    fontWeight: "normal",
+                    }}
+                  onChange={(e) => {
+                    setFormData((prev) => ({
+                      ...prev,
+                      enviromentSecrets: {
+                        ...prev.enviromentSecrets,
+                        [key]: e.target.value,
+                      },
+                    }));
+                    if (errors.enviromentSecrets && errors.enviromentSecrets[key]) setErrors({ ...errors, enviromentSecrets: { ...errors.enviromentSecrets, [key]: false } });
+                  }}
+                  placeholder={`Enter ${key}`}
+                  className={errors.enviromentSecrets[key] ? "border-red-500 focus:border-red-500" : ""}
+                />
+              </div>
+              ))}
+            </div>
+            )}
           </div>
         <DialogFooter>
           <RequestButton className="grid grid-cols-[auto] sm:grid-cols-1 gap-2" variant={"mainGreen"} request={handleDeploy}>


### PR DESCRIPTION
This pull request introduces improvements to the `HubServiceConfPopover` component, focusing on enhanced form handling, conditional rendering, and improved efficiency for fetching private buckets. The main changes include adding support for editing the `nodePort` field, improving the display of environment variables and secrets, and optimizing the fetching of private buckets based on the popover's open state.

**Form and UI enhancements:**

* Added a `nodePort` field to the form state, error state, and validation logic, and conditionally rendered a "Node Port" input when the service exposes a `nodePort` (`src/pages/ui/hub/components/HubServiceConfPopover/index.tsx`). [[1]](diffhunk://#diff-36400d3cd17e7ddbcb8c73b77abe89a6e95f0c9c5420b9fd1cc28ed7c68571e5R93) [[2]](diffhunk://#diff-36400d3cd17e7ddbcb8c73b77abe89a6e95f0c9c5420b9fd1cc28ed7c68571e5R123) [[3]](diffhunk://#diff-36400d3cd17e7ddbcb8c73b77abe89a6e95f0c9c5420b9fd1cc28ed7c68571e5R148) [[4]](diffhunk://#diff-36400d3cd17e7ddbcb8c73b77abe89a6e95f0c9c5420b9fd1cc28ed7c68571e5R164) [[5]](diffhunk://#diff-36400d3cd17e7ddbcb8c73b77abe89a6e95f0c9c5420b9fd1cc28ed7c68571e5R226) [[6]](diffhunk://#diff-36400d3cd17e7ddbcb8c73b77abe89a6e95f0c9c5420b9fd1cc28ed7c68571e5R425-R440)
* Improved the rendering of environment variables and secrets: now, sections for these fields are only displayed if there are any present, and each section has a label and separator for clarity (`src/pages/ui/hub/components/HubServiceConfPopover/index.tsx`). [[1]](diffhunk://#diff-36400d3cd17e7ddbcb8c73b77abe89a6e95f0c9c5420b9fd1cc28ed7c68571e5L587-R613) [[2]](diffhunk://#diff-36400d3cd17e7ddbcb8c73b77abe89a6e95f0c9c5420b9fd1cc28ed7c68571e5L612-R645) [[3]](diffhunk://#diff-36400d3cd17e7ddbcb8c73b77abe89a6e95f0c9c5420b9fd1cc28ed7c68571e5R670-R671)

**Performance and efficiency:**

* Updated the `useGetPrivateBuckets` hook to accept an `enabled` flag (defaulting to `true`), preventing unnecessary API calls when the popover is closed. The hook now only fetches buckets when enabled, and the dependency array includes `enabled` (`src/hooks/useGetPrivateBuckets.tsx`). [[1]](diffhunk://#diff-ee0e22d799cd5462bc029e7486b8f1866e00194e3c99c64786dbe9e5d4ee09b6L5-R12) [[2]](diffhunk://#diff-ee0e22d799cd5462bc029e7486b8f1866e00194e3c99c64786dbe9e5d4ee09b6L17-R21)
* Modified the popover to pass the `isOpen` state to `useGetPrivateBuckets`, ensuring buckets are only fetched when the popover is open (`src/pages/ui/hub/components/HubServiceConfPopover/index.tsx`).