### PR TITLE
Feat new ports spec transition implementation

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -32,14 +32,23 @@ import {
 } from "@/components/ui/sidebar";
 import { AnimatePresence, motion } from "framer-motion";
 import { Link, useLocation } from "react-router-dom";
-import { isVersionLower } from "@/lib/utils";
 import env from "@/env";
 
 function AppSidebar() {
   const authContext = useAuth();
-  const {clusterInfo} = useAuth();
   const { open } = useSidebar();
   const location = useLocation();
+
+  /*
+      },
+    // CHANGE ON NEW RELEASE Example
+    ...(clusterInfo && !isVersionLower(clusterInfo.version, "v3.8.0") ? [{
+      title: "Volumes",
+      icon: <HardDrive size={20} />,
+      path: "/volumes",
+    }] : []),
+    {
+  */
 
   const items = [
     {
@@ -52,12 +61,11 @@ function AppSidebar() {
       icon: <Database size={20} />,
       path: "/minio",
     },
-    // CHANGE ON NEW RELEASE
-    ...(clusterInfo && !isVersionLower(clusterInfo.version, "v3.8.0") ? [{
+    {
       title: "Volumes",
       icon: <HardDrive size={20} />,
       path: "/volumes",
-    }] : []),
+    },
     {
       title: "Notebooks",
       icon: <Notebook size={20} />,

--- a/src/pages/ui/flows/components/FlowsFormPopover/index.tsx
+++ b/src/pages/ui/flows/components/FlowsFormPopover/index.tsx
@@ -13,7 +13,7 @@ import createServiceApi from "@/api/services/createServiceApi";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
 import { Plus, RefreshCcwIcon } from "lucide-react";
 import RequestButton from "@/components/RequestButton";
-import { fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs } from "@/lib/utils";
+import { fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, isVersionLower } from "@/lib/utils";
 import useGetPrivateBuckets from "@/hooks/useGetPrivateBuckets";
 import { errorMessage } from "@/lib/error";
 
@@ -21,7 +21,7 @@ import { errorMessage } from "@/lib/error";
 
 function FlowsFormPopover() {
   const [isOpen, setIsOpen] = useState(false);
-  const {systemConfig, authData } = useAuth();
+  const {systemConfig, authData, clusterInfo } = useAuth();
   const { refreshServices } = useServicesContext();
   const [newBucket, setNewBucket] = useState(false);
   const buckets = useGetPrivateBuckets();
@@ -107,7 +107,7 @@ function FlowsFormPopover() {
       const scriptResponse = await fetch(scriptUrl, fetchFromGitHubOptions);
       const scriptText = await scriptResponse.text();
 
-      const services = yamlToServices(fdlText, scriptText);
+      const services = yamlToServices(fdlText, scriptText, (!!clusterInfo && !isVersionLower(clusterInfo.version, "v4.1.0")));
       if (!services?.length) throw Error("No services found");
 
       const service = services[0];

--- a/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
+++ b/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
@@ -90,7 +90,7 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
     token: "",
     enviromentVars: {} as Record<string, string>,
     enviromentSecrets: {} as Record<string, string>,
-    nodePort: "",
+    nodePort: [] as number[],
   });
   const [newVolume, setNewVolume] = useState(false);
   const [volumes, setVolumes] = useState<ManagedVolume[]>([]);
@@ -145,7 +145,7 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
       token: genRandomString(128),
       enviromentVars: service.environment?.variables || {},
       enviromentSecrets: service.environment?.secrets || {},
-      nodePort: service.expose?.nodePort || "",
+      nodePort: service.expose?.nodePort?.length > 0 ? service.expose.nodePort : [],
     }));
     setNewBucket(false);
     setVolumes([]);
@@ -296,6 +296,10 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
           ...service.labels,
           oscar_hub: "true",
         },
+        expose: {
+          ...service.expose,
+          nodePort: formData.nodePort,
+        }
       };
       await createServiceApi(modifiedService);
       refreshServices();
@@ -422,20 +426,25 @@ return (
                   </SelectContent>
                 </Select>
             </div>
-            {service?.expose?.nodePort && (
-              <div>
-                <Label htmlFor="nodePort">Node Port</Label>
-                <Input
-                  id="nodePort"
-                  type="number"
-                  placeholder="Enter Node Port"
-                  value={formData.nodePort}
-                  className={errors.nodePort ? "border-red-500 focus:border-red-500" : ""}
-                  onChange={(e) => {
-                    setFormData({ ...formData, nodePort: e.target.value });
-                    if (errors.nodePort) setErrors({ ...errors, nodePort: false });
-                  }}
-                />
+            {service?.expose?.nodePort?.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {formData.nodePort.map((port, index) => (
+                <div key={index} className="w-full sm:w-[173px]">
+                  <Label htmlFor={`nodePort-${index}`}>{"Node Port to " + (service?.expose?.api_port[index] ?? "Unknown")}</Label>
+                  <Input
+                    id={`nodePort-${index}`}
+                    type="number"
+                    placeholder="Enter Node Port"
+                    value={port}
+                    className={errors.nodePort ? "border-red-500 focus:border-red-500" : ""}
+                    onChange={(e) => {
+                      const newNodePort = [...formData.nodePort];
+                      newNodePort[index] = Number(e.target.value);
+                      setFormData({ ...formData, nodePort: newNodePort });
+                      if (errors.nodePort) setErrors({ ...errors, nodePort: false });
+                    }}
+                  />
+                </div>))}
               </div>
             )}
 						{(asyncService || mountBucket) && 

--- a/src/pages/ui/juno/components/JunoFormPopover/index.tsx
+++ b/src/pages/ui/juno/components/JunoFormPopover/index.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useAuth } from "@/contexts/AuthContext";
 import useGetPrivateBuckets from "@/hooks/useGetPrivateBuckets";
 import { alert } from "@/lib/alert";
-import { convertDockerImageToMap, fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs } from "@/lib/utils";
+import { convertDockerImageToMap, fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, isVersionLower } from "@/lib/utils";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
 import { Service } from "@/pages/ui/services/models/service";
@@ -22,7 +22,7 @@ import { errorMessage } from "@/lib/error";
 
 function JunoFormPopover() {
   const [isOpen, setIsOpen] = useState(false);
-  const {systemConfig, authData } = useAuth();
+  const {systemConfig, authData, clusterInfo } = useAuth();
   const { refreshServices } = useServicesContext();
   const [newBucket, setNewBucket] = useState(false);
   const buckets = useGetPrivateBuckets();
@@ -109,7 +109,7 @@ function JunoFormPopover() {
       const scriptResponse = await fetch(scriptUrl, fetchFromGitHubOptions);
       const scriptText = await scriptResponse.text();
 
-      const services = yamlToServices(fdlText, scriptText);
+      const services = yamlToServices(fdlText, scriptText, (!!clusterInfo && !isVersionLower(clusterInfo.version, "v4.1.0")));
       if (!services?.length) throw Error("No services found");
       
       const service = services[0];

--- a/src/pages/ui/services/components/FDL/index.tsx
+++ b/src/pages/ui/services/components/FDL/index.tsx
@@ -17,12 +17,15 @@ import updateServiceApi from "@/api/services/updateServiceApi";
 import { alert } from "@/lib/alert";
 import RequestButton from "@/components/RequestButton";
 import yamlToServices from "./utils/yamlToService";
+import { useAuth } from "@/contexts/AuthContext";
+import { isVersionLower } from "@/lib/utils";
 
 function FDLForm() {
   const { showFDLModal, setShowFDLModal, refreshServices } =
     useServicesContext();
   const [selectedTab, setSelectedTab] = useState<"fdl" | "script">("fdl");
   const [editorKey, setEditorKey] = useState(0);
+  const { clusterInfo } = useAuth();
 
   const [fdl, setFdl] = useState("");
   const [script, setScript] = useState("");
@@ -53,7 +56,7 @@ function FDLForm() {
       return;
     }
 
-    const services = yamlToServices(fdl, script);
+    const services = yamlToServices(fdl, script, (!!clusterInfo && !isVersionLower(clusterInfo.version, "v4.1.0")));
     if (!services) {
       return;
     }

--- a/src/pages/ui/services/components/FDL/utils/yamlToService.ts
+++ b/src/pages/ui/services/components/FDL/utils/yamlToService.ts
@@ -1,15 +1,29 @@
 import YAML from "yaml";
-import { Service, ServiceVisibility } from "../../../models/service";
+import { Service, ServiceVisibility, TmpService } from "../../../models/service";
 import { alert } from "@/lib/alert";
 import { errorMessage } from "@/lib/error";
 
-const yamlToServices = (fdlString: string, scriptString: string) => {
+const yamlToServices = (fdlString: string, scriptString: string, exposePortsToArray = false) => {
   try {
+    const normalizePortList = (value: unknown): number[] | undefined => {
+      if (typeof value === "string" || typeof value === "number") {
+        return [Number(value)];
+      }
+
+      if (Array.isArray(value)) {
+        return value
+          .filter((port) => typeof port === "string" || typeof port === "number")
+          .map((port) => Number(port));
+      }
+
+      return undefined;
+    };
+
     const obj = YAML.parse(fdlString);
     const services: Service[] = [];
     const scriptContent = scriptString;
     if (obj.functions && obj.functions.oscar) {
-      obj.functions.oscar.forEach((service: Record<string, Service>) => {
+      obj.functions.oscar.forEach((service: Record<string, TmpService>) => {
         const serviceKey = Object.keys(service)[0];
         const serviceParams = service[serviceKey];
         serviceParams.script = scriptContent;
@@ -20,7 +34,21 @@ const yamlToServices = (fdlString: string, scriptString: string) => {
           serviceParams.visibility === ServiceVisibility.restricted
             ? serviceParams.allowed_users ?? []
             : [];
-        services.push(serviceParams);
+        if (serviceParams.expose && exposePortsToArray) {
+          if (serviceParams.expose.nodePort != null) {
+            const normalizedNodePort = normalizePortList(serviceParams.expose.nodePort);
+            if (normalizedNodePort) {
+              serviceParams.expose.nodePort = normalizedNodePort;
+            }
+          }
+          if (serviceParams.expose.api_port != null) {
+            const normalizedApiPort = normalizePortList(serviceParams.expose.api_port);
+            if (normalizedApiPort) {
+              serviceParams.expose.api_port = normalizedApiPort;
+            }
+          }
+        }
+        services.push(serviceParams as Service);
       });
     }
 

--- a/src/pages/ui/services/components/ServiceForm/utils/initialData.ts
+++ b/src/pages/ui/services/components/ServiceForm/utils/initialData.ts
@@ -50,10 +50,10 @@ export const defaultService: Service = {
   expose: {
     min_scale: "",
     max_scale: "",
-    api_port: "",
+    api_port: [],
     cpu_threshold: "",
     rewrite_target: false,
-    nodePort: "",
+    nodePort: [],
     default_command: false,
     set_auth: false,
     health_path: "",

--- a/src/pages/ui/services/components/ServicesList/index.tsx
+++ b/src/pages/ui/services/components/ServicesList/index.tsx
@@ -7,7 +7,7 @@ import DeleteDialog from "@/components/DeleteDialog";
 import { Service, ServiceVisibility } from "../../models/service";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ArrowDownToLine, LoaderPinwheel, Pencil, RefreshCw, Terminal, Trash2 } from "lucide-react";
+import { ArrowDownToLine, ExternalLink, LoaderPinwheel, Pencil, RefreshCw, Terminal, Trash2, WrapText } from "lucide-react";
 import OscarColors from "@/styles";
 import { Link, useNavigate } from "react-router-dom";
 import GenericTable, { ColumnDef } from "@/components/Table";
@@ -22,6 +22,7 @@ import getDeploymentStatusApi from "@/api/deployment/getDeploymentStatusApi";
 import { DeploymentStatus } from "../../models/deployment";
 import ServiceRedirectButton from "@/components/ServiceRedirectButton";
 import { isVersionLower, shortenFullname } from "@/lib/utils";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 
 interface DeploymentStatusCellProps {
   initialDeployment?: DeploymentStatus;
@@ -271,13 +272,33 @@ function ServicesList() {
                 button: (item) => (
                   <>
                   {item.expose.max_scale != "0" ?
+                (item?.expose?.nodePort?.length > 0 ?
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant={"link"} ref={(elem) => {buttonRef.current?.set(item.name, elem!)}} size="icon" tooltipLabel="Redirect">
+                          <WrapText />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent className="min-w-40">
+                        {item.expose.nodePort.map((port, index) => (
+                          <DropdownMenuItem key={index} onClick={() => {window.open(`${authData.endpoint}:${port}`, "_blank", "noopener,noreferrer");}}>
+                            <ExternalLink className="mr-2 h-4 w-4" />
+                            <div className="flex flex-row leading-tight items-center">
+                              <span className="text-[11px] uppercase tracking-wide text-muted-foreground mr-1">Port</span>
+                              <span className="font-mono text-sm font-semibold">{port}</span>
+                            </div>
+                          </DropdownMenuItem>
+                        ))}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  :
                     <ServiceRedirectButton 
                       className="flex items-center justify-center ml-2 mr-2 "
                       service={item}
                       endpoint={authData.endpoint}
                       healthcheckPath={item.expose.health_path}
                     />
-                    :
+                  ) :
                     <InvokePopover
                       service={item}
                       triggerRenderer={

--- a/src/pages/ui/services/models/service.ts
+++ b/src/pages/ui/services/models/service.ts
@@ -225,10 +225,24 @@ export interface Service {
   expose: {
     min_scale: string,
     max_scale: string,
-    api_port: string,
+    api_port: number[],
     cpu_threshold: string,
     rewrite_target: boolean,
-    nodePort: string,
+    nodePort: number[],
+    default_command: boolean,
+    set_auth: boolean
+    health_path: string;
+  };
+}
+
+export interface TmpService extends Omit<Service, "expose"> {
+  expose: {
+    min_scale: string,
+    max_scale: string,
+    api_port: number[] | number,
+    cpu_threshold: string,
+    rewrite_target: boolean,
+    nodePort: number[] | number,
     default_command: boolean,
     set_auth: boolean
     health_path: string;

--- a/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
+++ b/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
@@ -193,7 +193,7 @@ function TerminalFormPopover() {
       );
       const scriptText = await scriptResponse.text();
 
-      const services = yamlToServices(fdlText, scriptText);
+      const services = yamlToServices(fdlText, scriptText, (!!clusterInfo && !isVersionLower(clusterInfo.version, "v4.1.0")));
 
       if (!services?.length) {
         throw new Error("No services found");


### PR DESCRIPTION
This pull request introduces several improvements and refactors to how service port exposure is handled throughout the UI, particularly focusing on supporting multiple exposed ports (as arrays) instead of single values. It also ensures that the correct data structures and UI controls are used for these changes, and selectively applies new behaviors based on cluster version compatibility.

**Service port exposure improvements:**

* Refactored the `Service` model and related forms to represent `nodePort` and `api_port` as arrays of numbers instead of strings, enabling support for multiple exposed ports. A new `TmpService` type was introduced to help with type transitions between single values and arrays. [[1]](diffhunk://#diff-d2d8662bb7a5bf6aacf836386a15ad79389c12ba24f39dc1b631d004620f3c81L228-R245) [[2]](diffhunk://#diff-1dbc370d3986db5a54e72741352db1aac3816890f4d5104406d24d56e5a0b695L53-R56)
* Updated the `yamlToServices` utility to normalize `nodePort` and `api_port` fields to arrays when a new `exposePortsToArray` flag is set, and propagate this flag based on cluster version checks throughout the app. [[1]](diffhunk://#diff-7e38c87042866b162c85e25ea6cf5d0d2206ecbe8cc6785a29c28e434293ecc6L2-R26) [[2]](diffhunk://#diff-7e38c87042866b162c85e25ea6cf5d0d2206ecbe8cc6785a29c28e434293ecc6L23-R51) [[3]](diffhunk://#diff-cb6a1f74122fe170b690da767cb151c5ebe61bcb501f30ce7d597b212a5fdf9eL16-R24) [[4]](diffhunk://#diff-cb6a1f74122fe170b690da767cb151c5ebe61bcb501f30ce7d597b212a5fdf9eL110-R110) [[5]](diffhunk://#diff-66e2d736718a3452df2ca8a04158469daea1c387829867d3c4677b606ff6778cL11-R11) [[6]](diffhunk://#diff-66e2d736718a3452df2ca8a04158469daea1c387829867d3c4677b606ff6778cL25-R25) [[7]](diffhunk://#diff-66e2d736718a3452df2ca8a04158469daea1c387829867d3c4677b606ff6778cL112-R112) [[8]](diffhunk://#diff-4f0d9a43c2d0cb82394fe145e4bd59481062045387b9629b13ece8da57c577b2R20-R28) [[9]](diffhunk://#diff-4f0d9a43c2d0cb82394fe145e4bd59481062045387b9629b13ece8da57c577b2L56-R59) [[10]](diffhunk://#diff-0ad32ad0caad940b3f646eebb72aa76b463b4b6907384d0d9170acd576be6843L196-R196)

**UI and interaction updates for exposed ports:**

* Updated service configuration forms and popovers to handle multiple `nodePort` entries, displaying appropriate input fields for each port and updating the form state accordingly. [[1]](diffhunk://#diff-36400d3cd17e7ddbcb8c73b77abe89a6e95f0c9c5420b9fd1cc28ed7c68571e5L93-R93) [[2]](diffhunk://#diff-36400d3cd17e7ddbcb8c73b77abe89a6e95f0c9c5420b9fd1cc28ed7c68571e5L148-R148) [[3]](diffhunk://#diff-36400d3cd17e7ddbcb8c73b77abe89a6e95f0c9c5420b9fd1cc28ed7c68571e5R299-R302) [[4]](diffhunk://#diff-36400d3cd17e7ddbcb8c73b77abe89a6e95f0c9c5420b9fd1cc28ed7c68571e5L425-R447)
* Enhanced the services list UI to show a dropdown menu for services with multiple exposed ports, allowing users to select and open a redirect for each port. [[1]](diffhunk://#diff-8b741250d55af4448d6f18a817a050aaaeaec6a5be62f9540e6175eb03738ba1L10-R10) [[2]](diffhunk://#diff-8b741250d55af4448d6f18a817a050aaaeaec6a5be62f9540e6175eb03738ba1R25) [[3]](diffhunk://#diff-8b741250d55af4448d6f18a817a050aaaeaec6a5be62f9540e6175eb03738ba1R275-R301)

**Backward compatibility and version checks:**

* Added logic to only enable the new multi-port behavior for clusters at or above version `v4.1.0`, ensuring backward compatibility with older clusters. [[1]](diffhunk://#diff-cb6a1f74122fe170b690da767cb151c5ebe61bcb501f30ce7d597b212a5fdf9eL16-R24) [[2]](diffhunk://#diff-cb6a1f74122fe170b690da767cb151c5ebe61bcb501f30ce7d597b212a5fdf9eL110-R110) [[3]](diffhunk://#diff-66e2d736718a3452df2ca8a04158469daea1c387829867d3c4677b606ff6778cL11-R11) [[4]](diffhunk://#diff-66e2d736718a3452df2ca8a04158469daea1c387829867d3c4677b606ff6778cL25-R25) [[5]](diffhunk://#diff-66e2d736718a3452df2ca8a04158469daea1c387829867d3c4677b606ff6778cL112-R112) [[6]](diffhunk://#diff-4f0d9a43c2d0cb82394fe145e4bd59481062045387b9629b13ece8da57c577b2R20-R28) [[7]](diffhunk://#diff-4f0d9a43c2d0cb82394fe145e4bd59481062045387b9629b13ece8da57c577b2L56-R59) [[8]](diffhunk://#diff-0ad32ad0caad940b3f646eebb72aa76b463b4b6907384d0d9170acd576be6843L196-R196)

**Code cleanup and minor refactors:**

* Removed unused imports and commented-out code related to version checks in the sidebar. [[1]](diffhunk://#diff-f1b12560e6554131811567968fc9060342f5bd5e7ceac672ae095f095a814a6cL35-R52) [[2]](diffhunk://#diff-f1b12560e6554131811567968fc9060342f5bd5e7ceac672ae095f095a814a6cL55-R68)

These changes collectively improve the flexibility and user experience for managing services with multiple exposed ports, while maintaining compatibility with existing deployments.