### PR TITLE
Add external links to sidebar for blog, documentation, and repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^11.3.31",
     "jszip": "^3.10.1",
-    "lucide-react": "^0.509.0",
+    "lucide-react": "0.509.0",
     "next-themes": "^0.3.0",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.3.1",

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -2,11 +2,14 @@ import OscarLogo from "@/assets/oscar-big.png";
 import {
   Activity,
   BarChart2,
+  BookOpen,
   Boxes,
   ChartPie,
   Codesandbox,
   Database,
   FolderOpen,
+  Github,
+  Globe,
   HardDrive,
   Info,
   LogOut,
@@ -168,7 +171,13 @@ function AppSidebar() {
         >
           <AnimatePresence mode="popLayout">
             {open && (
-              <motion.img src={OscarLogo} alt="Oscar logo" width={140} />
+              <a
+                href="https://oscar.grycap.net/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <motion.img src={OscarLogo} alt="Oscar logo" width={140} />
+              </a>
             )}
           </AnimatePresence>
           <SidebarTrigger />
@@ -203,6 +212,40 @@ function AppSidebar() {
       <SidebarSeparator />
       <SidebarFooter>
         <SidebarMenu>
+          <SidebarMenuItem>
+            <div className="flex justify-center gap-4 mb-2 min-w-o truncate">
+              <a
+                href="https://oscar.grycap.net/blog"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Blog"
+                title="Blog"
+                style={{ color: "inherit", display: "inline-flex" }}
+              >
+                <Globe size={18} />
+              </a>
+              <a
+                href="https://docs.oscar.grycap.net/latest"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Documentation"
+                title="Documentation"
+                style={{ color: "inherit", display: "inline-flex" }}
+              >
+                <BookOpen size={18} />
+              </a>
+              <a
+                href="https://github.com/grycap/oscar"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Repository"
+                title="Repository"
+                style={{ color: "inherit", display: "inline-flex" }}
+              >
+                <Github size={18} />
+              </a>
+            </div>
+          </SidebarMenuItem>
           <SidebarMenuItem>
             <SidebarMenuButton asChild tooltip="Log out">
               <div


### PR DESCRIPTION
This pull request enhances the sidebar component by adding quick-access links to external resources (blog, documentation, and repository) and updates the way the Oscar logo is displayed. Additionally, it makes a minor adjustment to the `lucide-react` package version specification.

**Sidebar enhancements:**

* Added new icon buttons in the sidebar footer that link to the Oscar blog, documentation, and GitHub repository, each opening in a new tab and using the corresponding `Globe`, `BookOpen`, and `Github` icons.
* Wrapped the Oscar logo in a link that directs users to the main Oscar website, opening in a new tab.

**Dependency management:**

* Changed the `lucide-react` dependency version in `package.json` from a caret (`^0.509.0`) to an exact version (`0.509.0`) to ensure consistent builds.

**Icon imports:**

* Added imports for the `BookOpen`, `Globe`, and `Github` icons from `lucide-react` to support the new sidebar links.