### PR TITLE
Small fixes

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -99,7 +99,7 @@ function GenericTable<T extends object>({
   return (
     <div className="relative flex flex-col flex-grow flex-basis-0 overflow-hidden">
       <Table id="table">
-        <TableHeader id="table-header" className="sticky top-0 z-10 h-[34px]">
+        <TableHeader id="table-header" className="sticky top-0 z-0 h-[34px]">
           <TableRow
             style={{
               background: "white",

--- a/src/lib/alert.ts
+++ b/src/lib/alert.ts
@@ -5,12 +5,18 @@ import { toast } from "sonner";
 class ToastAlert {
   constructor() {}
 
-  private formatMessage(message: React.ReactNode | string) {
+  private formatMessage(message: React.ReactNode | string, copyable: boolean = false) {
     if (typeof message === "string") {
       return React.createElement(
         "span",
         {
-          className: "toast-message-scroll w-full",
+          onClick: () => {
+            if (!copyable) return;
+            navigator.clipboard.writeText(message);
+            alert.success("Alert message copied to clipboard");
+          },
+          title: `${copyable ? "Click to copy" : ""}`,
+          className: `toast-message-scroll w-full ${copyable ? "cursor-pointer" : ""}`,
         },
         message
       );
@@ -38,7 +44,7 @@ class ToastAlert {
       console.error(message);
     }
 
-    toast.error(this.formatMessage(message), {
+    toast.error(this.formatMessage(message, true), {
       style: {
         backgroundColor: OscarColors.Red,
         color: "white",

--- a/src/pages/ui/services/components/FDL/index.tsx
+++ b/src/pages/ui/services/components/FDL/index.tsx
@@ -65,6 +65,7 @@ function FDLForm() {
     if (existingService && services.length === 1) {
       services[0].name = formService.name;
     }
+    var createMode = true;
     const promises = services.map(async (service) => {
       try{
         await getServiceApi(service.name);
@@ -73,6 +74,7 @@ function FDLForm() {
         return response;
       }
         const response = await updateServiceApi(service);
+        createMode = false;
         return response;
     });
 
@@ -81,10 +83,10 @@ function FDLForm() {
     results.forEach((result, index) => {
       if (result.status === "rejected") {
         alert.error(
-          `Error creating service ${services[index].name}: ${result.reason.response.data}`
+          `Error ${createMode ? "creating" : "updating"} service ${services[index].name}: ${result.reason.response.data}`
         );
       } else {
-        alert.success(`Service ${services[index].name} created successfully`);
+        alert.success(`Service ${services[index].name} ${createMode ? "created" : "updated"} successfully`);
       }
     });
 

--- a/src/pages/ui/services/components/FDL/index.tsx
+++ b/src/pages/ui/services/components/FDL/index.tsx
@@ -69,12 +69,12 @@ function FDLForm() {
     const promises = services.map(async (service) => {
       try{
         await getServiceApi(service.name);
+        createMode = false;
       }catch (error) {
         const response = await createServiceApi(service);
         return response;
       }
         const response = await updateServiceApi(service);
-        createMode = false;
         return response;
     });
 

--- a/src/pages/ui/services/components/FDL/utils/yamlToService.ts
+++ b/src/pages/ui/services/components/FDL/utils/yamlToService.ts
@@ -54,7 +54,7 @@ const yamlToServices = (fdlString: string, scriptString: string, exposePortsToAr
 
   return services;
   } catch (error) {
-    alert.error(`Error creating service: ${errorMessage(error)}`);
+    alert.error(`Error: ${errorMessage(error)}`);
     return [];
   }
 


### PR DESCRIPTION
**User feedback and alert improvements:**

* Toast alert messages are now copyable by clicking on them, which copies the message to the clipboard and shows a confirmation alert. This is especially useful for error messages. [[1]](diffhunk://#diff-02735b49b578037b03d6fffce4963411d815d539c8f8627a9327ce0ef9045aa7L8-R19) [[2]](diffhunk://#diff-02735b49b578037b03d6fffce4963411d815d539c8f8627a9327ce0ef9045aa7L41-R47)
* Service creation and update flows now display more accurate success and error messages, indicating whether a service was created or updated. [[1]](diffhunk://#diff-4f0d9a43c2d0cb82394fe145e4bd59481062045387b9629b13ece8da57c577b2R68-R72) [[2]](diffhunk://#diff-4f0d9a43c2d0cb82394fe145e4bd59481062045387b9629b13ece8da57c577b2L84-R89)
* Error messages in the YAML-to-service conversion utility have been clarified to be less ambiguous, improving user understanding.

**UI adjustment:**

* The `z-index` of the table header in the `GenericTable` component was changed from `z-10` to `z-0` to address potential layering issues.