### PR TITLE
Feat: Integrate InlineFDLEditor component and update layout

### DIFF
--- a/src/pages/ui/services/components/ServiceForm/components/GeneralTab/components/InlineFDLEditor.tsx
+++ b/src/pages/ui/services/components/ServiceForm/components/GeneralTab/components/InlineFDLEditor.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useMemo, useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import Editor from "@monaco-editor/react";
+import RequestButton from "@/components/RequestButton";
+import useServicesContext from "@/pages/ui/services/context/ServicesContext";
+import createServiceApi from "@/api/services/createServiceApi";
+import getServiceApi from "@/api/services/getServiceApi";
+import updateServiceApi from "@/api/services/updateServiceApi";
+import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
+import { alert } from "@/lib/alert";
+import { getFDLAndScriptText, isVersionLower } from "@/lib/utils";
+import { useAuth } from "@/contexts/AuthContext";
+
+function InlineFDLEditor() {
+  const { formService, refreshServices } = useServicesContext();
+  const { clusterInfo } = useAuth();
+  const existingService = useMemo(
+    () =>
+      !!(
+        formService?.name &&
+        formService?.script &&
+        formService.script !== "script.sh"
+      ),
+    [formService]
+  );
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedTab, setSelectedTab] = useState<"fdl" | "script">("fdl");
+  const [editorKey, setEditorKey] = useState(0);
+  const [fdl, setFdl] = useState("");
+  const [script, setScript] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen || !formService) return;
+
+    const { fdlText, scriptText } = getFDLAndScriptText(formService);
+    setFdl(fdlText);
+    setScript(scriptText);
+    setSelectedTab("fdl");
+    setEditorKey((prev) => prev + 1);
+  }, [isOpen, formService]);
+
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const result = event.target?.result as string;
+      if (selectedTab === "fdl") {
+        setFdl(result);
+      } else {
+        setScript(result);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  async function handleSave() {
+    if (!fdl) {
+      alert.error("Please fill the FDL file");
+      return;
+    }
+
+    if (!script) {
+      alert.error("Please fill the script");
+      return;
+    }
+
+    const services = yamlToServices(
+      fdl,
+      script,
+      !!clusterInfo && !isVersionLower(clusterInfo.version, "v4.1.0")
+    );
+    if (!services || services.length === 0) {
+      return;
+    }
+
+    let createMode = true;
+    setIsSaving(true);
+
+    try {
+      const promises = services.map(async (service) => {
+        try {
+          await getServiceApi(service.name);
+          createMode = false;
+        } catch (error) {
+          const response = await createServiceApi(service);
+          return response;
+        }
+        const response = await updateServiceApi(service);
+        return response;
+      });
+
+      const results = await Promise.allSettled(promises);
+
+      results.forEach((result, index) => {
+        if (result.status === "rejected") {
+          alert.error(
+            `Error ${createMode ? "creating" : "updating"} service ${services[index].name}: ${result.reason.response?.data ?? result.reason}`
+          );
+        } else {
+          alert.success(
+            `Service ${services[index].name} ${createMode ? "created" : "updated"} successfully`
+          );
+        }
+      });
+
+      if (results.every((result) => result.status === "fulfilled")) {
+        setIsOpen(false);
+        refreshServices();
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-3 w-full">
+      <Button
+        variant="secondary"
+        className="w-full justify-center"
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        {isOpen ? "Hide FDL editor" : "Edit FDL and script inline"}
+      </Button>
+
+      {isOpen && (
+        <div className="border border-slate-200 rounded-xl bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950">
+          <div className="flex flex-col gap-4 mb-4">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-sm text-slate-600 dark:text-slate-300">
+                Edit the current service FDL and script directly in the panel.
+              </div>
+              <Input type="file" onChange={handleFileUpload} className="max-w-[260px]" />
+            </div>
+            <Tabs value={selectedTab} onValueChange={(value) => setSelectedTab(value as "fdl" | "script")} className="grid grid-cols-1 grid-rows-[auto_1fr]"> 
+              <TabsList>
+                <TabsTrigger value="fdl">FDL</TabsTrigger>
+                <TabsTrigger value="script">Script</TabsTrigger>
+              </TabsList>
+              <TabsContent value="fdl" className="min-h-[360px]">
+                <Editor
+                  key={`fdl-${editorKey}`}
+                  language="yaml"
+                  value={fdl}
+                  onChange={(value) => setFdl(value || "")}
+                  width="100%"
+                  height="100%"
+                  options={{ minimap: { enabled: false } }}
+                />
+              </TabsContent>
+              <TabsContent value="script" className="min-h-[360px]">
+                <Editor
+                  key={`script-${editorKey}`}
+                  language="javascript"
+                  value={script}
+                  onChange={(value) => setScript(value || "")}
+                  width="100%"
+                  height="100%"
+                  options={{ minimap: { enabled: false } }}
+                />
+              </TabsContent>
+            </Tabs>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+            <Button variant="ghost" onClick={() => setIsOpen(false)}>
+              Cancel
+            </Button>
+            <RequestButton request={handleSave} disabled={isSaving}>
+              {existingService ? "Update service" : "Create service"}
+            </RequestButton>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default InlineFDLEditor;

--- a/src/pages/ui/services/components/ServiceForm/components/GeneralTab/index.tsx
+++ b/src/pages/ui/services/components/ServiceForm/components/GeneralTab/index.tsx
@@ -14,8 +14,8 @@ import {
 } from "@/components/ui/select";
 import EnviromentVariables from "./components/EnviromentVariables";
 import ServiceFormCell from "../FormCell";
-import ScriptButton from "./components/ScriptButton";
-import { CheckIcon, CopyIcon, XIcon, ExternalLink, Download, FileCode } from "lucide-react";
+import InlineFDLEditor from "./components/InlineFDLEditor";
+import { CheckIcon, CopyIcon, XIcon, ExternalLink, Download } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { alert } from "@/lib/alert";
 import Divider from "@/components/ui/divider";
@@ -32,7 +32,7 @@ import { downloadString, getAllowedVOs, getFDLAndScriptText } from "@/lib/utils"
 import { useEffect } from "react";
 
 function ServiceGeneralTab() {
-  const { formService, setFormService, formMode, formFunctions, setShowFDLModal } =
+  const { formService, setFormService, formMode, formFunctions } =
     useServicesContext();
 
   const { handleChange, onBlur, errors } = formFunctions;
@@ -286,87 +286,89 @@ const serviceToDownload = getFDLAndScriptText(formService)
         </div>
       </ServiceFormCell>
       <Divider />
-      <ServiceFormCell title="Service specifications">
+      <ServiceFormCell title="Service Resources">
         <div className="grid grid-cols-1 gap-5 w-full max-w-6xl min-w-[720px]">
-        <div className="grid grid-cols-1 xl:grid-cols-2 gap-5 w-full max-w-5xl min-w-[720px] ">
-          <ScriptButton  />
-          <div className="grid grid-cols-[150px_150px_150px] gap-[10px] xl:pl-[40px] items-end">
-            <Input
-              id="cpu-input"
-              value={formService?.cpu}
-              onChange={(e) => {
-                handleChange(e, "cpu");
-              }}
-              label="CPU cores"
-              error={errors.cpu}
-              type="number"
-              step="0.1"
-            />
-            <Input
-              id="memory-input"
-              value={memory}
-              label="Memory"
-              onChange={(e) => {
-                setFormService((service: Service) => {
-                  return {
-                    ...service,
-                    memory: e.target.value + memoryUnits,
-                  };
-                });
-              }}
-              type="number"
-              error={errors.memory}
-            />
-            <Select
-              value={memoryUnits}
-              onValueChange={(value) => {
-                setFormService((service: Service) => {
-                  return {
-                    ...service,
-                    memory: memory + value,
-                  };
-                });
-              }}
-            >
-              <SelectTrigger id="memory-units-select" className="w-[75px]">
-                <SelectValue placeholder="Select unit" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="Mi">Mi</SelectItem>
-                <SelectItem value="Gi">Gi</SelectItem>
-              </SelectContent>
-            </Select>
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-5 w-full max-w-5xl min-w-[720px] ">
+            <div className="grid grid-cols-[150px_150px_150px] gap-[10px] xl:pl-[40px] items-end">
+              <Input
+                id="cpu-input"
+                value={formService?.cpu}
+                onChange={(e) => {
+                  handleChange(e, "cpu");
+                }}
+                label="CPU cores"
+                error={errors.cpu}
+                type="number"
+                step="0.1"
+              />
+              <Input
+                id="memory-input"
+                value={memory}
+                label="Memory"
+                onChange={(e) => {
+                  setFormService((service: Service) => {
+                    return {
+                      ...service,
+                      memory: e.target.value + memoryUnits,
+                    };
+                  });
+                }}
+                type="number"
+                error={errors.memory}
+              />
+              <Select
+                value={memoryUnits}
+                onValueChange={(value) => {
+                  setFormService((service: Service) => {
+                    return {
+                      ...service,
+                      memory: memory + value,
+                    };
+                  });
+                }}
+              >
+                <SelectTrigger id="memory-units-select" className="w-[75px]">
+                  <SelectValue placeholder="Select unit" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Mi">Mi</SelectItem>
+                  <SelectItem value="Gi">Gi</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
           </div>
         </div>
+      </ServiceFormCell>
+      <Divider />
+      <ServiceFormCell title="FDL / Script">
         {formMode === ServiceViewMode.Update && (
-        <div className="flex flex-row gap-[50px] items-center">
-          <Button
-            className="flex flex-row gap-2 items-center"
-            variant="secondary"
-            onClick={() => {setShowFDLModal(true);}}
-          >
-            <FileCode size={16} />
-            FDL Editor
-          </Button>
-          <Button
-            className="flex flex-row gap-2 items-center"
-            variant="secondary"
-            onClick={() => {downloadString(serviceToDownload.scriptText, `${formService.name}.yaml`, "application/yaml")}}
-          >
-            <Download size={16} />
-            Download FDL
-          </Button>
-          <Button
-            className="flex flex-row gap-2 items-center"
-            variant="secondary"
-            onClick={() => {downloadString(serviceToDownload.scriptText, `${formService.name}-script.sh`)}}
-          >
-            <Download size={16} />
-            Download Script
-          </Button>
-        </div>
+          <div className="grid gap-5 w-full max-w-6xl min-w-[720px]">
+            <InlineFDLEditor />
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-sm text-slate-600 dark:text-slate-300">
+                Download the service files for review or backup.
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+                <Button
+                  className="w-full sm:w-auto flex flex-row gap-2 items-center justify-center"
+                  variant="secondary"
+                  onClick={() => {downloadString(serviceToDownload.scriptText, `${formService.name}.yaml`, "application/yaml")}}
+                >
+                  <Download size={16} />
+                  Download FDL
+                </Button>
+                <Button
+                  className="w-full sm:w-auto flex flex-row gap-2 items-center justify-center"
+                  variant="secondary"
+                  onClick={() => {downloadString(serviceToDownload.scriptText, `${formService.name}-script.sh`)}}
+                >
+                  <Download size={16} />
+                  Download script
+                </Button>
+              </div>
+            </div>
+          </div>
         )}
-        </div>
       </ServiceFormCell>
       <Divider />
       <ServiceFormCell title="Annotations">


### PR DESCRIPTION
**Inline FDL/Script Editing:**

- Added a new `InlineFDLEditor` component that provides an inline, tabbed interface for editing both FDL and script files directly within the service form. This component includes file upload, Monaco code editor integration, and handles both creation and update flows for services.
- Updated the `GeneralTab` to use the new `InlineFDLEditor`, removing the old `ScriptButton` and modal-based FDL editor trigger. The FDL/script editing section is now always visible (when in update mode), improving discoverability and ease of use. [[1]](diffhunk://#diff-c803cbeb4c8110f1dc2a024992090aa495e240b8238d361e2640ecb4ec9430c7L17-R18) [[2]](diffhunk://#diff-c803cbeb4c8110f1dc2a024992090aa495e240b8238d361e2640ecb4ec9430c7L289-L292) [[3]](diffhunk://#diff-c803cbeb4c8110f1dc2a024992090aa495e240b8238d361e2640ecb4ec9430c7R340-R371)

**UI/UX Improvements:**

- Refactored the service form layout to separate "Service Resources" and "FDL / Script" into distinct sections, clarifying the form structure for users. [[1]](diffhunk://#diff-c803cbeb4c8110f1dc2a024992090aa495e240b8238d361e2640ecb4ec9430c7L289-L292) [[2]](diffhunk://#diff-c803cbeb4c8110f1dc2a024992090aa495e240b8238d361e2640ecb4ec9430c7R340-R371)
- Enhanced the download UI for service files, providing clear options to download FDL and script files side by side, with improved button layouts and descriptions.

**Code Cleanup:**

- Removed unused imports and props, such as `ScriptButton` and `setShowFDLModal`, to clean up the codebase and reflect the new inline editing approach. [[1]](diffhunk://#diff-c803cbeb4c8110f1dc2a024992090aa495e240b8238d361e2640ecb4ec9430c7L17-R18) [[2]](diffhunk://#diff-c803cbeb4c8110f1dc2a024992090aa495e240b8238d361e2640ecb4ec9430c7L35-R35)