### PR TITLE
feat: enhance service form creation to support inline editing

### DIFF
--- a/src/pages/ui/services/components/ServiceForm/components/GeneralTab/components/InlineFDLEditor.tsx
+++ b/src/pages/ui/services/components/ServiceForm/components/GeneralTab/components/InlineFDLEditor.tsx
@@ -5,16 +5,16 @@ import { Button } from "@/components/ui/button";
 import Editor from "@monaco-editor/react";
 import RequestButton from "@/components/RequestButton";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
-import createServiceApi from "@/api/services/createServiceApi";
-import getServiceApi from "@/api/services/getServiceApi";
 import updateServiceApi from "@/api/services/updateServiceApi";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import { alert } from "@/lib/alert";
 import { getFDLAndScriptText, isVersionLower } from "@/lib/utils";
 import { useAuth } from "@/contexts/AuthContext";
+import getServiceApi from "@/api/services/getServiceApi";
+import createServiceApi from "@/api/services/createServiceApi";
 
-function InlineFDLEditor() {
-  const { formService, refreshServices } = useServicesContext();
+function InlineFDLEditor({ mode = "api" }: { mode?: "api" | "inline-edit" }) {
+  const { formService, setFormService, refreshServices } = useServicesContext();
   const { clusterInfo } = useAuth();
   const existingService = useMemo(
     () =>
@@ -77,10 +77,14 @@ function InlineFDLEditor() {
     if (!services || services.length === 0) {
       return;
     }
+    if (mode === "inline-edit") {
+      setFormService(services[0]);
+      console.log("Updated formService:", services[0]);
+      return;
+    }
 
     let createMode = true;
     setIsSaving(true);
-
     try {
       const promises = services.map(async (service) => {
         try {
@@ -171,7 +175,7 @@ function InlineFDLEditor() {
               Cancel
             </Button>
             <RequestButton request={handleSave} disabled={isSaving}>
-              {existingService ? "Update service" : "Create service"}
+              { mode === "inline-edit" ? "Save changes" : existingService ? "Update service" : "Create service"}
             </RequestButton>
           </div>
         </div>

--- a/src/pages/ui/services/components/ServiceForm/components/GeneralTab/index.tsx
+++ b/src/pages/ui/services/components/ServiceForm/components/GeneralTab/index.tsx
@@ -289,7 +289,7 @@ const serviceToDownload = getFDLAndScriptText(formService)
       <ServiceFormCell title="Service Resources">
         <div className="grid grid-cols-1 gap-5 w-full max-w-6xl min-w-[720px]">
           <div className="grid grid-cols-1 xl:grid-cols-2 gap-5 w-full max-w-5xl min-w-[720px] ">
-            <div className="grid grid-cols-[150px_150px_150px] gap-[10px] xl:pl-[40px] items-end">
+            <div className="grid grid-cols-[150px_150px_150px] gap-[10px] items-end">
               <Input
                 id="cpu-input"
                 value={formService?.cpu}
@@ -341,9 +341,9 @@ const serviceToDownload = getFDLAndScriptText(formService)
       </ServiceFormCell>
       <Divider />
       <ServiceFormCell title="FDL / Script">
-        {formMode === ServiceViewMode.Update && (
+        { (
           <div className="grid gap-5 w-full max-w-6xl min-w-[720px]">
-            <InlineFDLEditor />
+            <InlineFDLEditor mode={formMode === ServiceViewMode.Create ? "inline-edit" : "api"} />
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="text-sm text-slate-600 dark:text-slate-300">
                 Download the service files for review or backup.


### PR DESCRIPTION
This pull request introduces improvements to the `InlineFDLEditor` component, allowing it to support both "api" and "inline-edit" modes. The changes enhance the flexibility of service editing and saving workflows in the UI, particularly for handling different service form modes.