### PR TITLE
fix indirect monaco-editor dependency error 

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@bithero:registry=https://codearq.net/api/packages/bithero-js/npm/

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.654.0",
-    "@bithero/monaco-editor-vite-plugin": "^1.0.2",
-    "@monaco-editor/react": "^4.6.0",
+    "@bithero/monaco-editor-vite-plugin": "^1.0.3",
+    "@monaco-editor/react": "^4.7.0",
+    "monaco-editor": "0.55.0",
     "axios": "^1.7.2",
     "chart.js": "^4.5.1",
     "chartjs-plugin-zoom": "^2.2.0",


### PR DESCRIPTION
Dependency updates:

* Upgraded `@bithero/monaco-editor-vite-plugin` to version `1.0.3` and `@monaco-editor/react` to version `4.7.0` in `package.json`. Also added an explicit dependency on `monaco-editor` version `0.55.0` for compatibility.

Registry configuration:

* Added a custom npm registry for the `@bithero` scope in `.npmrc`, pointing to `https://codearq.net/api/packages/bithero-js/npm/`.