### PR TITLE
Check version to work with no dns exposed services

### DIFF
--- a/src/components/ServiceRedirectButton/index.tsx
+++ b/src/components/ServiceRedirectButton/index.tsx
@@ -30,8 +30,8 @@ function ServiceRedirectButton({
   const { clusterInfo } = useAuth();
 
   const safeHealthcheckPath = healthcheckPath.startsWith("/") ? healthcheckPath.slice(1).trim() : healthcheckPath
-  const healthcheckLink = getExposedServiceUrl(endpoint, service.name, safeHealthcheckPath);
-  const exposedBaseLink = getExposedServiceUrl(endpoint, service.name);
+  const healthcheckLink = getExposedServiceUrl(endpoint, service.name, safeHealthcheckPath, clusterInfo?.version);
+  const exposedBaseLink = getExposedServiceUrl(endpoint, service.name, "", clusterInfo?.version);
   const serviceIsStopped = service.deployment?.state === "stopped";
       
   /**

--- a/src/components/SimpleServiceRedirectButton/index.tsx
+++ b/src/components/SimpleServiceRedirectButton/index.tsx
@@ -24,11 +24,11 @@ function SimpleServiceRedirectButton({
 }) {
   const [isAlive, setIsAlive] = useState<boolean | null>(null);
   const { clusterInfo } = useAuth();
-  const redirectLink = getExposedServiceUrl(endpoint, service.name, interpolateVariables(service, additionalExposedPathArgs));
+  const redirectLink = getExposedServiceUrl(endpoint, service.name, interpolateVariables(service, additionalExposedPathArgs), clusterInfo?.version);
   const serviceIsStopped = service.deployment?.state === "stopped";
 
   const safeHealthcheckPath = healthcheckPath.startsWith("/") ? healthcheckPath.slice(1).trim() : healthcheckPath
-  const healthcheckLink = getExposedServiceUrl(endpoint, service.name, safeHealthcheckPath);
+  const healthcheckLink = getExposedServiceUrl(endpoint, service.name, safeHealthcheckPath, clusterInfo?.version);
       
   /**
    * Interpolate variables in the additionalExposedPathArgs string.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,10 +12,25 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export function getExposedServiceUrl(endpoint: string, serviceName: string, path = "") {
+export const DNS_EXPOSED_SERVICES_VERSION = "v4.2.0";
+
+export function usesDNSRoutes(version?: string | null) {
+  return !!version && !isVersionLower(version, DNS_EXPOSED_SERVICES_VERSION);
+}
+
+export function getExposedServiceUrl(
+  endpoint: string,
+  serviceName: string,
+  path = "",
+  clusterVersion?: string | null,
+) {
   const url = new URL(endpoint);
-  url.hostname = `${serviceName}.${url.hostname}`;
-  url.pathname = "/";
+  if (usesDNSRoutes(clusterVersion)) {
+    url.hostname = `${serviceName}.${url.hostname}`;
+    url.pathname = "/";
+  } else {
+    url.pathname = `/system/services/${serviceName}/exposed/`;
+  }
   url.search = "";
   url.hash = "";
   return new URL(`./${path.replace(/^\/+/, "")}`, url).toString();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -36,6 +36,10 @@ export function getExposedServiceUrl(
   return new URL(`./${path.replace(/^\/+/, "")}`, url).toString();
 }
 
+export function useArrayPorts(version?: string | null) {
+  return !!version && !isVersionLower(version, "v4.1.0");
+}
+
 /**
  * Parses a Kubernetes CPU string and returns the value in millicores.
  * Supported formats: "2" (cores), "1500m" (millicores)

--- a/src/pages/ui/agents/components/AgentsFormPopover/index.tsx
+++ b/src/pages/ui/agents/components/AgentsFormPopover/index.tsx
@@ -11,7 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useAuth } from "@/contexts/AuthContext";
 import { alert } from "@/lib/alert";
 import { errorMessage } from "@/lib/error";
-import { fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, isVersionLower } from "@/lib/utils";
+import { fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, usesDNSRoutes } from "@/lib/utils";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import { defaultService } from "@/pages/ui/services/components/ServiceForm/utils/initialData";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
@@ -131,7 +131,7 @@ function AgentFormPopover() {
       const services = yamlToServices(
         fdlText,
         scriptText,
-        !!clusterInfo && !isVersionLower(clusterInfo.version, "v4.1.0")
+        usesDNSRoutes(clusterInfo?.version)
       );
       if (!services?.length) throw Error("No services found");
 

--- a/src/pages/ui/agents/components/AgentsFormPopover/index.tsx
+++ b/src/pages/ui/agents/components/AgentsFormPopover/index.tsx
@@ -11,7 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useAuth } from "@/contexts/AuthContext";
 import { alert } from "@/lib/alert";
 import { errorMessage } from "@/lib/error";
-import { fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, usesDNSRoutes } from "@/lib/utils";
+import { fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, useArrayPorts } from "@/lib/utils";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import { defaultService } from "@/pages/ui/services/components/ServiceForm/utils/initialData";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
@@ -131,7 +131,7 @@ function AgentFormPopover() {
       const services = yamlToServices(
         fdlText,
         scriptText,
-        usesDNSRoutes(clusterInfo?.version)
+        useArrayPorts(clusterInfo?.version)
       );
       if (!services?.length) throw Error("No services found");
 

--- a/src/pages/ui/agents/components/AgentsFormPopover/index.tsx
+++ b/src/pages/ui/agents/components/AgentsFormPopover/index.tsx
@@ -11,7 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useAuth } from "@/contexts/AuthContext";
 import { alert } from "@/lib/alert";
 import { errorMessage } from "@/lib/error";
-import { fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, useArrayPorts } from "@/lib/utils";
+import { fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, useArrayPorts, usesDNSRoutes } from "@/lib/utils";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import { defaultService } from "@/pages/ui/services/components/ServiceForm/utils/initialData";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
@@ -131,7 +131,8 @@ function AgentFormPopover() {
       const services = yamlToServices(
         fdlText,
         scriptText,
-        useArrayPorts(clusterInfo?.version)
+        useArrayPorts(clusterInfo?.version),
+        usesDNSRoutes(clusterInfo?.version)
       );
       if (!services?.length) throw Error("No services found");
 

--- a/src/pages/ui/agents/index.tsx
+++ b/src/pages/ui/agents/index.tsx
@@ -83,7 +83,7 @@ function AgentsView() {
     ): Promise<Service | undefined> => {
       const response = await fetch(roCrateServiceDef.fdlUrl);
       if (response.ok) {
-        const service = yamlToServices(await response.text(), "", true)![0];
+        const service = yamlToServices(await response.text(), "", true, true)![0];
         const services: Service = {
           ...service,
           environment: {

--- a/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
+++ b/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
@@ -27,7 +27,7 @@ import {
   generateReadableName,
   genRandomString,
   getAllowedVOs,
-  usesDNSRoutes,
+  useArrayPorts,
 } from "@/lib/utils";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
@@ -139,7 +139,7 @@ function FileBrowserFormPopover() {
         fetchFromGitHubOptions
       );
       const scriptText = await scriptResponse.text();
-      const services = yamlToServices(fdlText, scriptText, usesDNSRoutes(clusterInfo?.version));
+      const services = yamlToServices(fdlText, scriptText, useArrayPorts(clusterInfo?.version));
 
       if (!services?.length) {
         throw new Error("No services found");

--- a/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
+++ b/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
@@ -27,7 +27,7 @@ import {
   generateReadableName,
   genRandomString,
   getAllowedVOs,
-  isVersionLower,
+  usesDNSRoutes,
 } from "@/lib/utils";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
@@ -139,7 +139,7 @@ function FileBrowserFormPopover() {
         fetchFromGitHubOptions
       );
       const scriptText = await scriptResponse.text();
-      const services = yamlToServices(fdlText, scriptText, (!!clusterInfo && !isVersionLower(clusterInfo.version, "v4.1.0")));
+      const services = yamlToServices(fdlText, scriptText, usesDNSRoutes(clusterInfo?.version));
 
       if (!services?.length) {
         throw new Error("No services found");

--- a/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
+++ b/src/pages/ui/filebrowsers/components/FileBrowserFormPopover/index.tsx
@@ -28,6 +28,7 @@ import {
   genRandomString,
   getAllowedVOs,
   useArrayPorts,
+  usesDNSRoutes,
 } from "@/lib/utils";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
@@ -139,7 +140,7 @@ function FileBrowserFormPopover() {
         fetchFromGitHubOptions
       );
       const scriptText = await scriptResponse.text();
-      const services = yamlToServices(fdlText, scriptText, useArrayPorts(clusterInfo?.version));
+      const services = yamlToServices(fdlText, scriptText, useArrayPorts(clusterInfo?.version), usesDNSRoutes(clusterInfo?.version));
 
       if (!services?.length) {
         throw new Error("No services found");

--- a/src/pages/ui/flows/components/FlowsFormPopover/index.tsx
+++ b/src/pages/ui/flows/components/FlowsFormPopover/index.tsx
@@ -13,7 +13,7 @@ import createServiceApi from "@/api/services/createServiceApi";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
 import { Plus, RefreshCcwIcon } from "lucide-react";
 import RequestButton from "@/components/RequestButton";
-import { fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, usesDNSRoutes } from "@/lib/utils";
+import { fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, useArrayPorts, usesDNSRoutes } from "@/lib/utils";
 import { errorMessage } from "@/lib/error";
 import StorageSelectForm, { StorageSelectFormRef } from "@/components/StorageSelectForm";
 
@@ -103,7 +103,7 @@ function FlowsFormPopover() {
       const scriptText = await scriptResponse.text();
 
       const dnsRoutesEnabled = usesDNSRoutes(clusterInfo?.version);
-      const services = yamlToServices(fdlText, scriptText, dnsRoutesEnabled);
+      const services = yamlToServices(fdlText, scriptText, useArrayPorts(clusterInfo?.version));
       if (!services?.length) throw Error("No services found");
 
       const service = services[0];

--- a/src/pages/ui/flows/components/FlowsFormPopover/index.tsx
+++ b/src/pages/ui/flows/components/FlowsFormPopover/index.tsx
@@ -13,7 +13,7 @@ import createServiceApi from "@/api/services/createServiceApi";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
 import { Plus, RefreshCcwIcon } from "lucide-react";
 import RequestButton from "@/components/RequestButton";
-import { fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, isVersionLower } from "@/lib/utils";
+import { fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, usesDNSRoutes } from "@/lib/utils";
 import { errorMessage } from "@/lib/error";
 import StorageSelectForm, { StorageSelectFormRef } from "@/components/StorageSelectForm";
 
@@ -102,9 +102,8 @@ function FlowsFormPopover() {
       const scriptResponse = await fetch(scriptUrl, fetchFromGitHubOptions);
       const scriptText = await scriptResponse.text();
 
-      const usesDNSRoutes =
-        !!clusterInfo && !isVersionLower(clusterInfo.version, "v4.1.0");
-      const services = yamlToServices(fdlText, scriptText, usesDNSRoutes);
+      const dnsRoutesEnabled = usesDNSRoutes(clusterInfo?.version);
+      const services = yamlToServices(fdlText, scriptText, dnsRoutesEnabled);
       if (!services?.length) throw Error("No services found");
 
       const service = services[0];
@@ -126,7 +125,7 @@ function FlowsFormPopover() {
         environment: {
           variables: {
             ...service.environment.variables,
-            NODE_RED_BASE_URL: usesDNSRoutes
+            NODE_RED_BASE_URL: dnsRoutesEnabled
               ? "/"
               : `/system/services/${serviceName}/exposed`,
             NODE_RED_DIRECTORY: workspaceDir,

--- a/src/pages/ui/flows/components/FlowsFormPopover/index.tsx
+++ b/src/pages/ui/flows/components/FlowsFormPopover/index.tsx
@@ -103,7 +103,7 @@ function FlowsFormPopover() {
       const scriptText = await scriptResponse.text();
 
       const dnsRoutesEnabled = usesDNSRoutes(clusterInfo?.version);
-      const services = yamlToServices(fdlText, scriptText, useArrayPorts(clusterInfo?.version));
+      const services = yamlToServices(fdlText, scriptText, useArrayPorts(clusterInfo?.version), dnsRoutesEnabled);
       if (!services?.length) throw Error("No services found");
 
       const service = services[0];

--- a/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
+++ b/src/pages/ui/hub/components/HubServiceConfPopover/index.tsx
@@ -8,7 +8,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useAuth } from "@/contexts/AuthContext";
 import { alert } from "@/lib/alert";
-import { generateReadableName, genRandomString, getAllowedVOs } from "@/lib/utils";
+import { generateReadableName, genRandomString, getAllowedVOs, usesDNSRoutes } from "@/lib/utils";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
 import {
   ManagedVolume,
@@ -32,7 +32,7 @@ interface HubServiceConfPopoverProps {
 }
 
 function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, setIsOpen, className = "", variant = "default", title = "Deploy Service" }: HubServiceConfPopoverProps) {
-  const {systemConfig, authData } = useAuth();
+  const {systemConfig, authData, clusterInfo } = useAuth();
   const { refreshServices } = useServicesContext();
   const [newBucket, setNewBucket] = useState(false);
   const buckets = useGetPrivateBuckets(isOpen);
@@ -109,10 +109,18 @@ function HubServiceConfPopover({ roCrateServiceDef, service, isOpen = false, set
       `/services/${serviceName}/exposed`
     );
     if (newValue.includes(`/services/${serviceName}/exposed`)) {
-      formData.enviromentVars = {
-        ...formData.enviromentVars,
-        [key]: newValue,
-      };
+      const dnsRoutesEnabled = usesDNSRoutes(clusterInfo?.version);
+      if (dnsRoutesEnabled) {
+        formData.enviromentVars = {
+          ...formData.enviromentVars,
+          [key]: "/",
+        };
+      } else {
+        formData.enviromentVars = {
+          ...formData.enviromentVars,
+          [key]: newValue,
+        };
+      }
     }
     return newValue;
   }

--- a/src/pages/ui/hub/index.tsx
+++ b/src/pages/ui/hub/index.tsx
@@ -13,7 +13,7 @@ import { Service } from "../services/models/service";
 import GenericTable from "@/components/Table";
 import HubTableActions from "./components/HubTableActions";
 import LayoutSelect from "@/components/LayoutSelect";
-import { getHubServiceTypeTagColor, useArrayPorts } from "@/lib/utils";
+import { getHubServiceTypeTagColor, useArrayPorts, usesDNSRoutes } from "@/lib/utils";
 import HubSrcPopoverButton, { DEFAULT_SOURCES, GitHubSource } from "./components/HubSrcPopoverButton";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -33,7 +33,7 @@ function HubView() {
     ): Promise<Service | undefined> => {
       const response = await fetch(roCrateServiceDef.fdlUrl);
       if (response.ok) {
-        const service = yamlToServices(await response.text(), "", useArrayPorts(clusterInfo?.version))![0];
+        const service = yamlToServices(await response.text(), "", useArrayPorts(clusterInfo?.version), usesDNSRoutes(clusterInfo?.version))![0];
         const services: Service = {
           ...service,
           environment: {

--- a/src/pages/ui/hub/index.tsx
+++ b/src/pages/ui/hub/index.tsx
@@ -13,7 +13,7 @@ import { Service } from "../services/models/service";
 import GenericTable from "@/components/Table";
 import HubTableActions from "./components/HubTableActions";
 import LayoutSelect from "@/components/LayoutSelect";
-import { getHubServiceTypeTagColor, isVersionLower } from "@/lib/utils";
+import { getHubServiceTypeTagColor, usesDNSRoutes } from "@/lib/utils";
 import HubSrcPopoverButton, { DEFAULT_SOURCES, GitHubSource } from "./components/HubSrcPopoverButton";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -33,7 +33,7 @@ function HubView() {
     ): Promise<Service | undefined> => {
       const response = await fetch(roCrateServiceDef.fdlUrl);
       if (response.ok) {
-        const service = yamlToServices(await response.text(), "", (!!clusterInfo && !isVersionLower(clusterInfo.version, "v4.1.0")))![0];
+        const service = yamlToServices(await response.text(), "", usesDNSRoutes(clusterInfo?.version))![0];
         const services: Service = {
           ...service,
           environment: {

--- a/src/pages/ui/hub/index.tsx
+++ b/src/pages/ui/hub/index.tsx
@@ -13,7 +13,7 @@ import { Service } from "../services/models/service";
 import GenericTable from "@/components/Table";
 import HubTableActions from "./components/HubTableActions";
 import LayoutSelect from "@/components/LayoutSelect";
-import { getHubServiceTypeTagColor, usesDNSRoutes } from "@/lib/utils";
+import { getHubServiceTypeTagColor, useArrayPorts } from "@/lib/utils";
 import HubSrcPopoverButton, { DEFAULT_SOURCES, GitHubSource } from "./components/HubSrcPopoverButton";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -33,7 +33,7 @@ function HubView() {
     ): Promise<Service | undefined> => {
       const response = await fetch(roCrateServiceDef.fdlUrl);
       if (response.ok) {
-        const service = yamlToServices(await response.text(), "", usesDNSRoutes(clusterInfo?.version))![0];
+        const service = yamlToServices(await response.text(), "", useArrayPorts(clusterInfo?.version))![0];
         const services: Service = {
           ...service,
           environment: {

--- a/src/pages/ui/juno/components/JunoFormPopover/index.tsx
+++ b/src/pages/ui/juno/components/JunoFormPopover/index.tsx
@@ -7,7 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useAuth } from "@/contexts/AuthContext";
 import { alert } from "@/lib/alert";
-import { convertDockerImageToMap, fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, isVersionLower } from "@/lib/utils";
+import { convertDockerImageToMap, fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, usesDNSRoutes } from "@/lib/utils";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
 import { Service } from "@/pages/ui/services/models/service";
@@ -105,7 +105,8 @@ function JunoFormPopover() {
       const scriptResponse = await fetch(scriptUrl, fetchFromGitHubOptions);
       const scriptText = await scriptResponse.text();
 
-      const services = yamlToServices(fdlText, scriptText, (!!clusterInfo && !isVersionLower(clusterInfo.version, "v4.1.0")));
+      const dnsRoutesEnabled = usesDNSRoutes(clusterInfo?.version);
+      const services = yamlToServices(fdlText, scriptText, dnsRoutesEnabled);
       if (!services?.length) throw Error("No services found");
       
       const service = services[0];
@@ -127,12 +128,14 @@ function JunoFormPopover() {
         cpu: formData.cpuCores,
         expose: {
           ...service.expose,
-          rewrite_target: false,
+          ...(dnsRoutesEnabled ? { rewrite_target: false } : {}),
         },
         environment: {
           variables: {
             ...service.environment.variables,
-            JHUB_BASE_URL: "/",
+            JHUB_BASE_URL: dnsRoutesEnabled
+              ? "/"
+              : `/system/services/${serviceName}/exposed`,
             JUPYTER_DIRECTORY: workspaceDir,
             GRANT_SUDO: "yes",
             OSCAR_ENDPOINT: authData.endpoint,

--- a/src/pages/ui/juno/components/JunoFormPopover/index.tsx
+++ b/src/pages/ui/juno/components/JunoFormPopover/index.tsx
@@ -106,7 +106,7 @@ function JunoFormPopover() {
       const scriptText = await scriptResponse.text();
 
       const dnsRoutesEnabled = usesDNSRoutes(clusterInfo?.version);
-      const services = yamlToServices(fdlText, scriptText, useArrayPorts(clusterInfo?.version));
+      const services = yamlToServices(fdlText, scriptText, useArrayPorts(clusterInfo?.version), dnsRoutesEnabled);
       if (!services?.length) throw Error("No services found");
       
       const service = services[0];

--- a/src/pages/ui/juno/components/JunoFormPopover/index.tsx
+++ b/src/pages/ui/juno/components/JunoFormPopover/index.tsx
@@ -7,7 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useAuth } from "@/contexts/AuthContext";
 import { alert } from "@/lib/alert";
-import { convertDockerImageToMap, fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, usesDNSRoutes } from "@/lib/utils";
+import { convertDockerImageToMap, fetchFromGitHubOptions, generateReadableName, genRandomString, getAllowedVOs, useArrayPorts, usesDNSRoutes } from "@/lib/utils";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
 import { Service } from "@/pages/ui/services/models/service";
@@ -106,7 +106,7 @@ function JunoFormPopover() {
       const scriptText = await scriptResponse.text();
 
       const dnsRoutesEnabled = usesDNSRoutes(clusterInfo?.version);
-      const services = yamlToServices(fdlText, scriptText, dnsRoutesEnabled);
+      const services = yamlToServices(fdlText, scriptText, useArrayPorts(clusterInfo?.version));
       if (!services?.length) throw Error("No services found");
       
       const service = services[0];

--- a/src/pages/ui/services/components/FDL/index.tsx
+++ b/src/pages/ui/services/components/FDL/index.tsx
@@ -18,7 +18,7 @@ import { alert } from "@/lib/alert";
 import RequestButton from "@/components/RequestButton";
 import yamlToServices from "./utils/yamlToService";
 import { useAuth } from "@/contexts/AuthContext";
-import { getFDLAndScriptText, usesDNSRoutes } from "@/lib/utils";
+import { getFDLAndScriptText, useArrayPorts, usesDNSRoutes } from "@/lib/utils";
 
 function FDLForm() {
   const { showFDLModal, setShowFDLModal, refreshServices, formService } =
@@ -58,7 +58,7 @@ function FDLForm() {
       return;
     }
 
-    const services = yamlToServices(fdl, script, usesDNSRoutes(clusterInfo?.version));
+    const services = yamlToServices(fdl, script, useArrayPorts(clusterInfo?.version), usesDNSRoutes(clusterInfo?.version));
     if (!services) {
       return;
     }

--- a/src/pages/ui/services/components/FDL/index.tsx
+++ b/src/pages/ui/services/components/FDL/index.tsx
@@ -18,7 +18,7 @@ import { alert } from "@/lib/alert";
 import RequestButton from "@/components/RequestButton";
 import yamlToServices from "./utils/yamlToService";
 import { useAuth } from "@/contexts/AuthContext";
-import { getFDLAndScriptText, isVersionLower } from "@/lib/utils";
+import { getFDLAndScriptText, usesDNSRoutes } from "@/lib/utils";
 
 function FDLForm() {
   const { showFDLModal, setShowFDLModal, refreshServices, formService } =
@@ -58,7 +58,7 @@ function FDLForm() {
       return;
     }
 
-    const services = yamlToServices(fdl, script, (!!clusterInfo && !isVersionLower(clusterInfo.version, "v4.1.0")));
+    const services = yamlToServices(fdl, script, usesDNSRoutes(clusterInfo?.version));
     if (!services) {
       return;
     }

--- a/src/pages/ui/services/components/FDL/utils/yamlToService.ts
+++ b/src/pages/ui/services/components/FDL/utils/yamlToService.ts
@@ -3,7 +3,7 @@ import { Service, ServiceVisibility, TmpService } from "../../../models/service"
 import { alert } from "@/lib/alert";
 import { errorMessage } from "@/lib/error";
 
-const yamlToServices = (fdlString: string, scriptString: string, exposePortsToArray = false) => {
+const yamlToServices = (fdlString: string, scriptString: string, exposePortsToArray = false, exposedDNSRoutesSupport = false) => {
   try {
     const normalizePortList = (value: unknown): number[] | undefined => {
       if (typeof value === "string" || typeof value === "number") {
@@ -46,6 +46,11 @@ const yamlToServices = (fdlString: string, scriptString: string, exposePortsToAr
             if (normalizedApiPort) {
               serviceParams.expose.api_port = normalizedApiPort;
             }
+          }
+        }
+        if (serviceParams.expose && exposedDNSRoutesSupport) {
+          if (serviceParams.expose.rewrite_target) {
+            serviceParams.expose.rewrite_target = false;
           }
         }
         services.push(serviceParams as Service);

--- a/src/pages/ui/services/components/ServiceForm/components/GeneralTab/components/InlineFDLEditor.tsx
+++ b/src/pages/ui/services/components/ServiceForm/components/GeneralTab/components/InlineFDLEditor.tsx
@@ -8,7 +8,7 @@ import useServicesContext from "@/pages/ui/services/context/ServicesContext";
 import updateServiceApi from "@/api/services/updateServiceApi";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import { alert } from "@/lib/alert";
-import { getFDLAndScriptText, usesDNSRoutes } from "@/lib/utils";
+import { getFDLAndScriptText, useArrayPorts } from "@/lib/utils";
 import { useAuth } from "@/contexts/AuthContext";
 import getServiceApi from "@/api/services/getServiceApi";
 import createServiceApi from "@/api/services/createServiceApi";
@@ -72,7 +72,7 @@ function InlineFDLEditor({ mode = "api" }: { mode?: "api" | "inline-edit" }) {
     const services = yamlToServices(
       fdl,
       script,
-      usesDNSRoutes(clusterInfo?.version)
+      useArrayPorts(clusterInfo?.version)
     );
     if (!services || services.length === 0) {
       return;

--- a/src/pages/ui/services/components/ServiceForm/components/GeneralTab/components/InlineFDLEditor.tsx
+++ b/src/pages/ui/services/components/ServiceForm/components/GeneralTab/components/InlineFDLEditor.tsx
@@ -8,7 +8,7 @@ import useServicesContext from "@/pages/ui/services/context/ServicesContext";
 import updateServiceApi from "@/api/services/updateServiceApi";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import { alert } from "@/lib/alert";
-import { getFDLAndScriptText, useArrayPorts } from "@/lib/utils";
+import { getFDLAndScriptText, useArrayPorts, usesDNSRoutes } from "@/lib/utils";
 import { useAuth } from "@/contexts/AuthContext";
 import getServiceApi from "@/api/services/getServiceApi";
 import createServiceApi from "@/api/services/createServiceApi";
@@ -72,7 +72,8 @@ function InlineFDLEditor({ mode = "api" }: { mode?: "api" | "inline-edit" }) {
     const services = yamlToServices(
       fdl,
       script,
-      useArrayPorts(clusterInfo?.version)
+      useArrayPorts(clusterInfo?.version),
+      usesDNSRoutes(clusterInfo?.version)
     );
     if (!services || services.length === 0) {
       return;

--- a/src/pages/ui/services/components/ServiceForm/components/GeneralTab/components/InlineFDLEditor.tsx
+++ b/src/pages/ui/services/components/ServiceForm/components/GeneralTab/components/InlineFDLEditor.tsx
@@ -8,7 +8,7 @@ import useServicesContext from "@/pages/ui/services/context/ServicesContext";
 import updateServiceApi from "@/api/services/updateServiceApi";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import { alert } from "@/lib/alert";
-import { getFDLAndScriptText, isVersionLower } from "@/lib/utils";
+import { getFDLAndScriptText, usesDNSRoutes } from "@/lib/utils";
 import { useAuth } from "@/contexts/AuthContext";
 import getServiceApi from "@/api/services/getServiceApi";
 import createServiceApi from "@/api/services/createServiceApi";
@@ -72,7 +72,7 @@ function InlineFDLEditor({ mode = "api" }: { mode?: "api" | "inline-edit" }) {
     const services = yamlToServices(
       fdl,
       script,
-      !!clusterInfo && !isVersionLower(clusterInfo.version, "v4.1.0")
+      usesDNSRoutes(clusterInfo?.version)
     );
     if (!services || services.length === 0) {
       return;

--- a/src/pages/ui/services/components/ServiceForm/components/GeneralTab/index.tsx
+++ b/src/pages/ui/services/components/ServiceForm/components/GeneralTab/index.tsx
@@ -36,7 +36,7 @@ function ServiceGeneralTab() {
     useServicesContext();
 
   const { handleChange, onBlur, errors } = formFunctions;
-  const { systemConfig, authData } = useAuth();
+  const { systemConfig, authData, clusterInfo } = useAuth();
   const voGroups = getAllowedVOs(systemConfig, authData);
   function voGroupsIsEmpthy(){
     if( voGroups === undefined){ return true}
@@ -244,7 +244,7 @@ const serviceToDownload = getFDLAndScriptText(formService)
                 <strong>Exposed:</strong>
                 {formService.expose?.api_port ? (
                   <Link
-                    to={getExposedServiceUrl(authData.endpoint, formService.name)}
+                    to={getExposedServiceUrl(authData.endpoint, formService.name, "", clusterInfo?.version)}
                     target="_blank"
                   >
                     <ExternalLink size={18} />

--- a/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
+++ b/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
@@ -28,6 +28,7 @@ import {
   generateReadableName,
   genRandomString,
   getAllowedVOs,
+  useArrayPorts,
   usesDNSRoutes,
 } from "@/lib/utils";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
@@ -135,7 +136,7 @@ function TerminalFormPopover() {
       const scriptText = await scriptResponse.text();
 
       const dnsRoutesEnabled = usesDNSRoutes(clusterInfo?.version);
-      const services = yamlToServices(fdlText, scriptText, dnsRoutesEnabled);
+      const services = yamlToServices(fdlText, scriptText, useArrayPorts(clusterInfo?.version));
 
       if (!services?.length) {
         throw new Error("No services found");

--- a/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
+++ b/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
@@ -28,7 +28,7 @@ import {
   generateReadableName,
   genRandomString,
   getAllowedVOs,
-  isVersionLower,
+  usesDNSRoutes,
 } from "@/lib/utils";
 import yamlToServices from "@/pages/ui/services/components/FDL/utils/yamlToService";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
@@ -134,7 +134,8 @@ function TerminalFormPopover() {
       );
       const scriptText = await scriptResponse.text();
 
-      const services = yamlToServices(fdlText, scriptText, (!!clusterInfo && !isVersionLower(clusterInfo.version, "v4.1.0")));
+      const dnsRoutesEnabled = usesDNSRoutes(clusterInfo?.version);
+      const services = yamlToServices(fdlText, scriptText, dnsRoutesEnabled);
 
       if (!services?.length) {
         throw new Error("No services found");
@@ -167,7 +168,9 @@ function TerminalFormPopover() {
           variables: {
             ...service.environment.variables,
             SERVICE_NAME: serviceName,
-            BASE_PATH: `/system/services/${serviceName}/exposed`,
+            BASE_PATH: dnsRoutesEnabled
+              ? "/"
+              : `/system/services/${serviceName}/exposed`,
             WORKSPACE_DIR: workspaceDir,
           },
           secrets: formData.refreshToken

--- a/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
+++ b/src/pages/ui/terminals/components/TerminalFormPopover/index.tsx
@@ -136,7 +136,7 @@ function TerminalFormPopover() {
       const scriptText = await scriptResponse.text();
 
       const dnsRoutesEnabled = usesDNSRoutes(clusterInfo?.version);
-      const services = yamlToServices(fdlText, scriptText, useArrayPorts(clusterInfo?.version));
+      const services = yamlToServices(fdlText, scriptText, useArrayPorts(clusterInfo?.version), dnsRoutesEnabled);
 
       if (!services?.length) {
         throw new Error("No services found");


### PR DESCRIPTION
This PR will enable the dashboard to work also with old cluster that uses no DNS exposed services.
To avoid the dasboard to fail with already deployed OSCAR clusters (<4.2.0)