### PR TITLE
fix: disable delete button for non-owners in BucketList and ServicesList components

### DIFF
--- a/src/pages/ui/minio/components/BucketList/index.tsx
+++ b/src/pages/ui/minio/components/BucketList/index.tsx
@@ -179,18 +179,25 @@ export default function BucketList() {
         actions={[
           {
             button: (bucket) => {
-              return (
-                <>
-                  <Button
-                    variant="link"
+              const isOwner = authData.egiSession?.sub === bucket.owner;
+              if (!isOwner) {
+                return <Button
+                    variant={"link"}
                     size="icon"
-                    onClick={() => {
-                      setItemsToDelete([...itemsToDelete, bucket]);
-                    }}
+                    disabled
                   >
-                    <Trash color={OscarColors.Red} />
-                  </Button>
-                </>
+                </Button>;
+              }
+              return (
+                <Button
+                  variant="link"
+                  size="icon"
+                  onClick={() => {
+                    setItemsToDelete([...itemsToDelete, bucket]);
+                  }}
+                >
+                  <Trash color={OscarColors.Red} />
+                </Button>
               );
             },
           },

--- a/src/pages/ui/services/components/ServicesList/index.tsx
+++ b/src/pages/ui/services/components/ServicesList/index.tsx
@@ -369,16 +369,27 @@ function ServicesList() {
                 ),
               },
               {
-                button: (item) => (
-                  <Button
-                    variant={"link"}
-                    size="icon"
-                    onClick={() => setServicesToDelete([item])}
-                    tooltipLabel="Delete"
-                  >
+                button: (item) => {
+                  const isOwner = authData.egiSession?.sub === item.owner;
+                  if (!isOwner) {
+                    return <Button
+                        variant={"link"}
+                        size="icon"
+                        disabled
+                      >
+                    </Button>;
+                  }
+                  return (
+                    <Button
+                      variant={"link"}
+                      size="icon"
+                      onClick={() => setServicesToDelete([item])}
+                      tooltipLabel="Delete"
+                    >
                     <Trash2 color={OscarColors.Red} />
                   </Button>
-                ),
+                  );
+                },
               },
             ]}
             bulkActions={[


### PR DESCRIPTION
This pull request introduces access control improvements to the UI by ensuring that only resource owners can see and interact with the delete buttons in both the bucket list and services list components. If the current user is not the owner, the delete button is shown as disabled, preventing unauthorized deletions.

**Access control for delete actions:**

* [`src/pages/ui/minio/components/BucketList/index.tsx`](diffhunk://#diff-2b1f24f9f6580d96c11212cc22c26833c8d9274b8bbb75ca82ae86e014b2615eR182-L183): Added a check to ensure the delete button is only enabled for the bucket owner; otherwise, a disabled button is rendered. [[1]](diffhunk://#diff-2b1f24f9f6580d96c11212cc22c26833c8d9274b8bbb75ca82ae86e014b2615eR182-L183) [[2]](diffhunk://#diff-2b1f24f9f6580d96c11212cc22c26833c8d9274b8bbb75ca82ae86e014b2615eL193)
* [`src/pages/ui/services/components/ServicesList/index.tsx`](diffhunk://#diff-8b741250d55af4448d6f18a817a050aaaeaec6a5be62f9540e6175eb03738ba1L372-R382): Added a similar ownership check so that only the service owner can use the delete button, displaying a disabled button for non-owners. [[1]](diffhunk://#diff-8b741250d55af4448d6f18a817a050aaaeaec6a5be62f9540e6175eb03738ba1L372-R382) [[2]](diffhunk://#diff-8b741250d55af4448d6f18a817a050aaaeaec6a5be62f9540e6175eb03738ba1L381-R392)