### PR TITLE
fix: enhance loopback hostname check to support subdomains

### DIFF
--- a/public/callback.html
+++ b/public/callback.html
@@ -41,7 +41,7 @@
             const endpointURL = new URL(endpoint);
             const originURL = new URL(currentOrigin);
             const isLoopbackHostname = (hostname) =>
-              hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1';
+              hostname === 'localhost' || hostname.startsWith('localhost') || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1';
 
             const isLoopbackUpgrade =
               endpointURL.protocol === 'http:' &&


### PR DESCRIPTION
This pull request makes a small update to the loopback hostname detection logic in `public/callback.html`. The change ensures that hostnames starting with `localhost` (such as `localhost.localdomain`) are also recognized as loopback addresses.

- Improved loopback hostname detection by updating the `isLoopbackHostname` function to include hostnames that start with `localhost` (e.g., `localhost.localdomain`).