### PR TITLE
fix: update localhost deployment check for Minio endpoint (for docker)

### DIFF
--- a/src/contexts/Minio/MinioContext.tsx
+++ b/src/contexts/Minio/MinioContext.tsx
@@ -99,7 +99,7 @@ export type MinioProviderData = {
 };
 
 function isLocalhostDeployed(endpoint:string){
-  if (env.response_default_minio === endpoint){
+  if (env.response_default_minio === endpoint || endpoint.includes("host.docker.internal")){
     return true
   }else return false
 }
@@ -128,7 +128,9 @@ export const MinioProvider = ({ children }: { children: React.ReactNode }) => {
       !providerInfo.region
     )
       return null;
-    providerInfo.endpoint =  isLocalhostDeployed(providerInfo.endpoint) ? "http://"+env.minio_local_endpoint+":"+env.minio_local_port : providerInfo.endpoint;
+
+    const minioPort = providerInfo.endpoint.split(":")[2] ?? env.minio_local_port;
+    providerInfo.endpoint =  isLocalhostDeployed(providerInfo.endpoint) ? "http://localhost:"+minioPort : providerInfo.endpoint;
     return new S3Client({
       region: providerInfo.region,
       endpoint: providerInfo.endpoint,


### PR DESCRIPTION
**Improvements to endpoint detection and rewriting:**

* Updated the `isLocalhostDeployed` function to treat endpoints containing `"host.docker.internal"` as localhost deployments, in addition to matching the default Minio endpoint.
* Modified the logic for setting the Minio endpoint so that if the deployment is recognized as localhost (including Docker internal host), it rewrites the endpoint to use `http://localhost:<port>`, extracting the port from the original endpoint or falling back to the default local port from the environment.
