### PR TITLE
feat: implement service secret API calls in EnviromentSecrets component

### DIFF
--- a/src/api/services/getServiceSecretApi.ts
+++ b/src/api/services/getServiceSecretApi.ts
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+async function getServiceSecretApi(serviceName: string, secretName: string): Promise<string> {
+  const response = await axios.get(`/system/services/${serviceName}/secrets`, {
+    params: {
+      key: secretName,
+    },
+  });
+
+  return response.data as string;
+}
+
+export default getServiceSecretApi;

--- a/src/api/services/updateServiceSecretApi.ts
+++ b/src/api/services/updateServiceSecretApi.ts
@@ -1,0 +1,11 @@
+import axios from "axios";
+
+async function updateServiceSecretApi(serviceName: string, secret: Record<string, string>): Promise<string> {
+  const response = await axios.put(`/system/services/${serviceName}/secrets`, {
+    data: secret
+  });
+
+  return response.data as string;
+}
+
+export default updateServiceSecretApi;

--- a/src/pages/ui/services/components/ServiceForm/components/GeneralTab/components/EnviromentSecrets.tsx
+++ b/src/pages/ui/services/components/ServiceForm/components/GeneralTab/components/EnviromentSecrets.tsx
@@ -1,5 +1,7 @@
+import getServiceSecretApi from "@/api/services/getServiceSecretApi";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { SecretInput } from "@/components/ui/secretInput";
 import useServicesContext from "@/pages/ui/services/context/ServicesContext";
 import { Plus, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -22,6 +24,19 @@ function EnviromentSecrets() {
   }, [formService]);
 
   const [secretsArray, setSecretsArray] = useState(initialArray);
+
+
+  async function handleGetSecret(secretName: string): Promise<string> {
+    // Call the API to get the secret value
+    return await getServiceSecretApi(formService.name, secretName)
+      .then((secret) => {
+        return secret;
+      })
+      .catch((error) => {
+        console.error("Error fetching secret:", error);
+        return "";
+      });
+  }
 
   useEffect(() => {
     setFormService((prev) => ({
@@ -59,7 +74,7 @@ function EnviromentSecrets() {
             }}
             placeholder="Secret name"
           />
-          <Input
+          <SecretInput
             id={`secret-value-input-${index}`}
             type="password"
             value={variable.value}
@@ -72,6 +87,7 @@ function EnviromentSecrets() {
               setSecretsArray(newVariablesArray);
             }}
             placeholder="Value"
+            getSecretHandler={() => handleGetSecret(variable.key)}
           />
           {secretsArray.length > 0 && (
             <Button


### PR DESCRIPTION
Waiting for https://github.com/grycap/oscar/pull/623

**API Integration for Service Secrets:**

* Added `getServiceSecretApi` to fetch a specific secret value for a service via a GET request (`src/api/services/getServiceSecretApi.ts`).
* Added `updateServiceSecretApi` to update a service secret via a PUT request (`src/api/services/updateServiceSecretApi.ts`).

**UI Updates for Secret Management:**

* Updated the `EnviromentSecrets` component to import and use `getServiceSecretApi`, providing a `handleGetSecret` function that retrieves secret values and handles errors (`src/pages/ui/services/components/ServiceForm/components/GeneralTab/components/EnviromentSecrets.tsx`). [[1]](diffhunk://#diff-3fa06abb181abfe203c533d36584c3f5fcffd77f6f55e34c25fc614e75ae9cebR1-R4) [[2]](diffhunk://#diff-3fa06abb181abfe203c533d36584c3f5fcffd77f6f55e34c25fc614e75ae9cebR28-R40)
* Replaced the standard `Input` with `SecretInput` for secret values, ensuring secrets are handled securely in the UI (`EnviromentSecrets.tsx`).
* Passed a `getSecretHandler` prop to `SecretInput`, allowing the UI to fetch and display the secret value on demand (`EnviromentSecrets.tsx`).

