### PR TITLE
Fix missing OIDC session handling in notebook views

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -24,7 +24,10 @@ type EGISessionInfo = {
   sub: string; // Unique user identifier
   voperson_verified_email: string[]; // List of verified email addresses
 
-  group_membership: string[]; 
+  group_membership: string[];
+  realm_access?: {
+    roles?: string[];
+  };
 };
 
 export type AuthData = {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -196,8 +196,8 @@ export function getUserVOs(authData: AuthData): string[] {
       });
     });
   }
-  if ((authData.egiSession as any).realm_access?.roles) {
-    (authData.egiSession as any).realm_access.roles.forEach((role: string) => {
+  if (authData.egiSession?.realm_access?.roles) {
+    authData.egiSession.realm_access.roles.forEach((role: string) => {
       // "platform-access:vo.example.eu"
       const match = role.match(/^platform-access:(vo\..+?)$/);
       if (match && match[1]) {


### PR DESCRIPTION
This PR addresses the error obtained when executing the Notebook dashboard tests:

```sh
 make test auth-keycloak-gmolto cluster-localhost ROBOT_SUITE=tests/dashboard/notebooks.robot 
Auth config: variables/.env-auth-keycloak-gmolto.yaml
Cluster config: variables/.env-cluster-localhost.yaml
Robot suite: tests/dashboard/notebooks.robot
Robot args: 
OSCAR_TEST_AUTH_GOAL="auth-keycloak-gmolto" \
        OSCAR_TEST_CLUSTER_GOAL="cluster-localhost" \
        OSCAR_TEST_AUTH_FILE="variables/.env-auth-keycloak-gmolto.yaml" \
        OSCAR_TEST_CLUSTER_FILE="variables/.env-cluster-localhost.yaml" \
        OSCAR_TEST_ROBOT=".venv/bin/robot" \
        OSCAR_TEST_ROBOT_SUITE="tests/dashboard/notebooks.robot" \
        OSCAR_TEST_ROBOT_ARGS="" \
        OSCAR_TEST_ROBOT_OUTPUT_DIR="robot_results" \
        PYTHONWARNINGS="ignore:Unverified HTTPS request is being made" .venv/bin/robot -V variables/.env-auth-keycloak-gmolto.yaml -V variables/.env-cluster-localhost.yaml  -d robot_results tests/dashboard/notebooks.robot
==============================================================================
Notebooks :: UI regression tests for the Notebooks panel.                     
==============================================================================
[ WARN ] Endpoint field not found on login page. Continuing with token injection.
Notebooks Panel Navigation Works :: Ensures the Notebooks panel ca... | PASS |
------------------------------------------------------------------------------
Notebooks Table Columns Visible :: Checks that the Notebooks table... | FAIL |
TimeoutError: locator.waitFor: Timeout 10000ms exceeded.
Call log:
  - waiting for locator('//th[normalize-space()=\'Name\']') to be visible
------------------------------------------------------------------------------
New Notebook Button Is Present :: Verifies that users can trigger ... | FAIL |
TimeoutError: locator.waitFor: Timeout 10000ms exceeded.
Call log:
  - waiting for locator('role=button[name="New"]') to be visible
------------------------------------------------------------------------------
Notebooks :: UI regression tests for the Notebooks panel.             | FAIL |
3 tests, 1 passed, 2 failed
==============================================================================
Output:  /Users/gmolto/Documents/GitHub/grycap/oscar-tests/robot_results/output.xml
Log:     /Users/gmolto/Documents/GitHub/grycap/oscar-tests/robot_results/log.html
Report:  /Users/gmolto/Documents/GitHub/grycap/oscar-tests/robot_results/report.html
make: *** [test] Error 2
```




## Summary

- model optional Keycloak `realm_access` roles in the OIDC session type
- guard access to role claims when `egiSession` is absent
- remove the unsafe `any` cast from VO extraction

## Root cause

Token-based dashboard sessions can omit `egiSession`, but `getUserVOs` accessed `realm_access` before checking whether the session existed. Rendering the Notebooks deployment form then raised a runtime `TypeError` and left the page blank.

## Impact

Notebook and other integrated-app views can render safely for token-based or incomplete OIDC sessions. Existing VO role filtering remains unchanged when role claims are present.

## Validation

- `npx eslint src/contexts/AuthContext.tsx src/lib/utils.ts --report-unused-disable-directives --max-warnings 0`
- `npm run build`

The repository-wide lint still reports the pre-existing `no-var` error in `src/pages/ui/services/components/FDL/index.tsx:72`.