### PR TITLE
Fix OSCAR website link in sidebar

### DIFF
--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -221,7 +221,7 @@ function AppSidebar() {
           <SidebarMenuItem>
             <div className="flex justify-center gap-4 mb-2 min-w-o truncate">
               <a
-                href="https://oscar.grycap.net/blog"
+                href="https://oscar.grycap.net"
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Blog"

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -224,8 +224,8 @@ function AppSidebar() {
                 href="https://oscar.grycap.net"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="Blog"
-                title="Blog"
+                aria-label="OSCAR website"
+                title="OSCAR website"
                 style={{ color: "inherit", display: "inline-flex" }}
               >
                 <Globe size={18} />


### PR DESCRIPTION
## Summary
- update the sidebar globe icon link from `https://oscar.grycap.net/blog` to `https://oscar.grycap.net`

## Verification
- `npm run build`
- targeted ESLint check for `src/components/Sidebar/index.tsx`
- confirmed the destination returns HTTP 200

## Note
- the full repository lint currently fails on an unrelated pre-existing `no-var` error in `src/pages/ui/services/components/FDL/index.tsx:72`